### PR TITLE
Fix loan form state restoration

### DIFF
--- a/src/components/take a loan/LoanFlowWrapper.jsx
+++ b/src/components/take a loan/LoanFlowWrapper.jsx
@@ -1,11 +1,14 @@
+import { useCallback, useEffect, useState } from "react";
 import { Outlet, useBlocker } from "react-router-dom";
 import { useLoanForm } from "../../context/LoanFormContext";
-import LoanFlowStepper from "./LoanFlowStepper";
-import { useEffect, useState, useCallback } from "react";
 import CancelApplicationModal from "./CancelApplicationModal";
+import LoanFlowStepper from "./LoanFlowStepper";
 
 export default function LoanFlowWrapper() {
-  const { clearLoanFormData } = useLoanForm();
+  const { clearLoanFormData, hasLoanFormData, hasUnsavedChanges } =
+    useLoanForm();
+
+  const shouldWarnBeforeLeaving = hasLoanFormData || hasUnsavedChanges;
   const [showModal, setShowModal] = useState(false);
 
   // Paths that are considered "inside" the loan application experience.
@@ -16,12 +19,16 @@ export default function LoanFlowWrapper() {
 
   // Block ANY navigation that goes outside allowed prefixes.
   const blocker = useBlocker(
-    useCallback(({ nextLocation }) => {
-      const isStillInFlow = ALLOWED_PREFIXES.some((p) =>
-        nextLocation.pathname.startsWith(p)
-      );
-      return !isStillInFlow; // true = block
-    }, [])
+    useCallback(
+      ({ nextLocation }) => {
+        const isStillInFlow = ALLOWED_PREFIXES.some((prefix) =>
+          nextLocation.pathname.startsWith(prefix),
+        );
+
+        return shouldWarnBeforeLeaving && !isStillInFlow;
+      },
+      [shouldWarnBeforeLeaving],
+    ),
   );
 
   // Show / hide modal in response to blocker state
@@ -35,15 +42,21 @@ export default function LoanFlowWrapper() {
 
   // Warn on tab close / reload while in flow
   useEffect(() => {
-    const handleBeforeUnload = (e) => {
-      // Because wrapper only mounts while in-flow, *always* warn.
-      e.preventDefault();
-      e.returnValue = "";
+    if (!shouldWarnBeforeLeaving) {
+      return undefined;
+    }
+
+    const handleBeforeUnload = (event) => {
+      event.preventDefault();
+      event.returnValue = "";
     };
+
     window.addEventListener("beforeunload", handleBeforeUnload);
-    return () =>
+
+    return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, []);
+    };
+  }, [shouldWarnBeforeLeaving]);
 
   const confirmLeave = () => {
     setShowModal(false);
@@ -75,4 +88,3 @@ export default function LoanFlowWrapper() {
     </div>
   );
 }
-

--- a/src/components/take a loan/Step1LoanAmount.jsx
+++ b/src/components/take a loan/Step1LoanAmount.jsx
@@ -1,16 +1,14 @@
-
-
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useLocation, useNavigate } from "react-router-dom";
+import * as yup from "yup";
+import { getBorrowingLimit } from "../../api/loansApi";
 import chevronDown from "../../assets/chevron-down.svg";
 import chevronUp from "../../assets/chevron-up.svg";
-import LoadingSpinner from "../LoadingSpinner";
-import { useState, useEffect } from "react";
-import * as yup from "yup";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { useForm } from "react-hook-form";
-import { useNavigate, useLocation } from "react-router-dom";
 import { useLoanForm } from "../../context/LoanFormContext";
-import { useTranslation } from "react-i18next";
-import { getBorrowingLimit } from "../../api/loansApi";
+import LoadingSpinner from "../LoadingSpinner";
 
 export default function Step1LoanAmount() {
   const { t } = useTranslation();
@@ -47,7 +45,7 @@ export default function Step1LoanAmount() {
       .min(1000, t("loanStep1.errors.loanAmountMin"))
       .max(
         borrowingLimit,
-        t("loanStep1.errors.loanAmountMax", { limit: borrowingLimit })
+        t("loanStep1.errors.loanAmountMax", { limit: borrowingLimit }),
       ),
     loanPurpose: yup
       .string()
@@ -67,6 +65,7 @@ export default function Step1LoanAmount() {
     register,
     handleSubmit,
     setValue,
+    reset,
     watch,
     formState: { errors, isDirty },
   } = useForm({
@@ -76,9 +75,28 @@ export default function Step1LoanAmount() {
       loanAmount: loanFormData.loan_amount,
       loanPurpose: loanFormData.loan_purpose,
       otherPurpose: loanFormData.other_purpose,
-      wapanMembership: loanFormData.wapan_member,
+      wapanMembership:
+        loanFormData.wapan_member === true
+          ? "Yes"
+          : loanFormData.wapan_member === false
+            ? "No"
+            : "",
     },
   });
+
+  useEffect(() => {
+    reset({
+      loanAmount: loanFormData.loan_amount,
+      loanPurpose: loanFormData.loan_purpose,
+      otherPurpose: loanFormData.other_purpose,
+      wapanMembership:
+        loanFormData.wapan_member === true
+          ? "Yes"
+          : loanFormData.wapan_member === false
+            ? "No"
+            : "",
+    });
+  }, [loanFormData, reset]);
 
   const loanPurpose = watch("loanPurpose");
   const wapanMembership = watch("wapanMembership");
@@ -241,8 +259,8 @@ export default function Step1LoanAmount() {
               {wapanMembership === "Yes"
                 ? t("loanStep1.options.yes")
                 : wapanMembership === "No"
-                ? t("loanStep1.options.no")
-                : t("loanStep1.membershipPlaceholder")}
+                  ? t("loanStep1.options.no")
+                  : t("loanStep1.membershipPlaceholder")}
             </p>
             <img
               src={displayMembershipForm ? chevronUp : chevronDown}
@@ -260,7 +278,7 @@ export default function Step1LoanAmount() {
                     setValue(
                       "wapanMembership",
                       value === "true" ? "Yes" : "No",
-                      { shouldValidate: true }
+                      { shouldValidate: true },
                     );
                     setDisplayMembershipForm(false);
                   }}

--- a/src/context/LoanFormContext.jsx
+++ b/src/context/LoanFormContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 
 const LoanFormContext = createContext();
 
@@ -6,19 +6,37 @@ export function useLoanForm() {
   return useContext(LoanFormContext);
 }
 
+const emptyLoanFormData = {
+  loan_amount: "",
+  loan_purpose: "",
+  other_purpose: "",
+  wapan_member: "",
+  account_name: "",
+  account_number: "",
+  bank_name: "",
+  repayment_method: "",
+  recyclable_drop_off_known: "",
+  repayment_schedule: "",
+  recyclable_drop_off_location: "",
+};
+
 export function LoanFormProvider({ children }) {
-  const [loanFormData, setLoanFormData] = useState({
-    loan_amount: "",
-    loan_purpose: "",
-    other_purpose: "",
-    wapan_member: "",
-    account_name: "",
-    account_number: "",
-    bank_name: "",
-    repayment_method: "",
-    recyclable_drop_off_known: "",
-    repayment_schedule: "",
-    recyclable_drop_off_location: "",
+  const [loanFormData, setLoanFormData] = useState(() => {
+    try {
+      const storedDraft = localStorage.getItem("loanApplicationDraft");
+
+      if (storedDraft) {
+        const parsedDraft = JSON.parse(storedDraft);
+
+        if (parsedDraft && typeof parsedDraft === "object") {
+          return { ...emptyLoanFormData, ...parsedDraft };
+        }
+      }
+    } catch {
+      localStorage.removeItem("loanApplicationDraft");
+    }
+
+    return { ...emptyLoanFormData };
   });
 
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
@@ -26,6 +44,12 @@ export function LoanFormProvider({ children }) {
 
   // On mount, restore saved loan application data if any
   useEffect(() => {
+    const storedDraft = localStorage.getItem("loanApplicationDraft");
+
+    if (storedDraft) {
+      return;
+    }
+
     try {
       const stored = localStorage.getItem("latestLoanApplicationData");
       if (stored) {
@@ -36,13 +60,15 @@ export function LoanFormProvider({ children }) {
           loan_amount: restoredData.loan_amount ?? "",
           loan_purpose: restoredData.loan_purpose ?? "",
           other_purpose: restoredData.loan_purpose_other ?? "",
-          wapan_member: restoredData.wapan_member ?? false,
+          wapan_member: restoredData.wapan_member ?? "",
           account_name: restoredData.bank_account?.account_name ?? "",
           account_number: restoredData.bank_account?.account_number ?? "",
           bank_name: restoredData.bank_account?.bank_name ?? "",
           repayment_method: restoredData.repayment_method ?? "",
-          recyclable_drop_off_known: restoredData.recyclable_drop_off_known ?? false,
-          recyclable_drop_off_location: restoredData.recyclable_drop_off_location ?? "",
+          recyclable_drop_off_known:
+            restoredData.recyclable_drop_off_known ?? false,
+          recyclable_drop_off_location:
+            restoredData.recyclable_drop_off_location ?? "",
           repayment_schedule: restoredData.repayment_schedule ?? "",
         });
       }
@@ -55,30 +81,27 @@ export function LoanFormProvider({ children }) {
   function updateLoanFormData(newData) {
     setLoanFormData((prev) => {
       const updated = { ...prev, ...newData };
+
       if (JSON.stringify(prev) !== JSON.stringify(updated)) {
         setHasUnsavedChanges(true);
+        localStorage.setItem("loanApplicationDraft", JSON.stringify(updated));
       }
+
       return updated;
     });
   }
 
   function clearLoanFormData() {
-    setLoanFormData({
-      loan_amount: "",
-      loan_purpose: "",
-      wapan_member: "",
-      account_name: "",
-      account_number: "",
-      bank_name: "",
-      repayment_method: "",
-      recyclable_drop_off_known: "",
-      repayment_schedule: "",
-      recyclable_drop_off_location: "",
-    });
+    setLoanFormData({ ...emptyLoanFormData });
     setHasUnsavedChanges(false);
     setFormSubmitted(true);
-    localStorage.removeItem("latestLoanApplicationData"); 
+    localStorage.removeItem("loanApplicationDraft");
+    localStorage.removeItem("latestLoanApplicationData");
   }
+
+  const hasLoanFormData = Object.values(loanFormData).some(
+    (value) => value !== "" && value !== null && value !== undefined,
+  );
 
   return (
     <LoanFormContext.Provider
@@ -86,6 +109,7 @@ export function LoanFormProvider({ children }) {
         loanFormData,
         updateLoanFormData,
         clearLoanFormData,
+        hasLoanFormData,
         hasUnsavedChanges,
         setHasUnsavedChanges,
         formSubmitted,


### PR DESCRIPTION
## Summary
- Restore WAPAN membership correctly when revisiting Step 1
- Persist completed loan-form steps across page refreshes
- Avoid navigation warnings when the form is empty
- Clear frontend draft data during explicit cancellation
- Clear the other-purpose field when resetting the form

## Verification
- Production build passes
- WAPAN Yes and No values restore correctly
- Completed steps survive page refresh
- Empty forms do not trigger the navigation modal
- Explicit cancellation clears frontend data for users without a backend pending loan