### PR TITLE
Add pending loan cancellation

### DIFF
--- a/src/api/loansApi.js
+++ b/src/api/loansApi.js
@@ -10,6 +10,11 @@ export const updatePendingLoanDetails = async (loanFormData, loanID) => {
   return response;
 };
 
+export const cancelPendingLoan = async (loanID) => {
+  const response = await axios.patch(`/loans/${loanID}/cancel`);
+  return response;
+};
+
 export const confirmLoanApplication = async (loan_id, password) => {
   const response = await axios.post("/loans/confirm", {
     loan_id,

--- a/src/components/take a loan/CancelApplicationModal.jsx
+++ b/src/components/take a loan/CancelApplicationModal.jsx
@@ -1,44 +1,53 @@
-
-
 import { useTranslation } from "react-i18next";
+import LoadingSpinner from "../LoadingSpinner";
 
 export default function CancelApplicationModal({
   onConfirm,
   onCancel,
   loading,
-  // error,
-  targetLocation,
+  error,
+  success,
 }) {
   const { t } = useTranslation();
 
   return (
     <div className="w-[90%] mx-auto lg:w-[50%] text-center text-[#222] bg-white rounded-[12px] flex flex-col gap-10 py-7 px-5">
-      {/* {error && (
-        <p className="text-red-500 mb-3">
-          Something went wrong. Please try again.
-        </p>
-      )} */}
       <p className="text-[18px] md:text-[20px]">
         {t("cancelApplicationModal.title")}
       </p>
       <p className="text-[rgba(68,68,68,0.80)]">
         {t("cancelApplicationModal.body")}
       </p>
+      {error && (
+        <p className="text-red-500 text-sm" role="alert">
+          {error}
+        </p>
+      )}
+
+      {success && (
+        <p className="text-green-600 text-sm" role="status">
+          {success}
+        </p>
+      )}
       <div className="flex items-center justify-center gap-6">
         <button
-          disabled={loading}
+          disabled={loading || Boolean(success)}
           onClick={onCancel}
           className={`border border-[rgba(0,0,0,0.08)] font-medium rounded-[40px] bg-white py-2.5 px-6 hover:opacity-60 transition-opacity duration-300 ${
-            loading ? "duration-300 cursor-not-allowed" : "cursor-pointer"
+            loading || success
+              ? "cursor-not-allowed opacity-60"
+              : "cursor-pointer"
           }`}
         >
-          {loading ? <LoadingSpinner /> : t("cancelApplicationModal.noButton")}
+          {t("cancelApplicationModal.noButton")}
         </button>
         <button
-          disabled={loading}
-          onClick={() => onConfirm(targetLocation)}
+          disabled={loading || Boolean(success)}
+          onClick={onConfirm}
           className={`text-white bg-[#439182] font-medium border border-[rgba(0,0,0,0.08)] rounded-[40px] py-2.5 px-6 hover:opacity-80 transition-opacity duration-300 ${
-            loading ? "duration-300 cursor-not-allowed" : "cursor-pointer"
+            loading || success
+              ? "cursor-not-allowed opacity-60"
+              : "cursor-pointer"
           }`}
         >
           {loading ? <LoadingSpinner /> : t("cancelApplicationModal.yesButton")}

--- a/src/components/take a loan/LoanFlowWrapper.jsx
+++ b/src/components/take a loan/LoanFlowWrapper.jsx
@@ -1,10 +1,21 @@
 import { useCallback, useEffect, useState } from "react";
 import { Outlet, useBlocker } from "react-router-dom";
+import { useDashboard } from "../../context/DashboardContext";
 import { useLoanForm } from "../../context/LoanFormContext";
 import CancelApplicationModal from "./CancelApplicationModal";
 import LoanFlowStepper from "./LoanFlowStepper";
+import { cancelPendingLoan } from "../../api/loansApi";
+import { useTranslation } from "react-i18next";
 
 export default function LoanFlowWrapper() {
+  const { t } = useTranslation();
+
+  const { dashboardData, refreshDashboardData } = useDashboard();
+
+  const [cancellationLoading, setCancellationLoading] = useState(false);
+  const [cancellationError, setCancellationError] = useState("");
+  const [cancellationSuccess, setCancellationSuccess] = useState("");
+
   const { clearLoanFormData, hasLoanFormData, hasUnsavedChanges } =
     useLoanForm();
 
@@ -58,16 +69,62 @@ export default function LoanFlowWrapper() {
     };
   }, [shouldWarnBeforeLeaving]);
 
-  const confirmLeave = () => {
+  const completeCancellation = () => {
+    clearLoanFormData();
     setShowModal(false);
-    clearLoanFormData(); // cancel application
+
     if (blocker.state === "blocked") {
       blocker.proceed();
     }
   };
 
+  const confirmLeave = async () => {
+    const pendingLoanID = dashboardData?.pending_loan?._id;
+
+    setCancellationError("");
+    setCancellationSuccess("");
+
+    // Nothing exists on the backend yet.
+    if (!pendingLoanID) {
+      completeCancellation();
+      return;
+    }
+
+    setCancellationLoading(true);
+
+    try {
+      const response = await cancelPendingLoan(pendingLoanID);
+
+      if (response.status === 200 && response.data?.status) {
+        await refreshDashboardData();
+
+        setCancellationSuccess(
+          response.data?.message || t("cancelApplicationModal.cancelSuccess")
+        );
+
+        setTimeout(() => {
+          completeCancellation();
+        }, 1500);
+      } else {
+        setCancellationError(
+          response.data?.message || t("cancelApplicationModal.cancelError"),
+        );
+      }
+    } catch (error) {
+      setCancellationError(
+        error.response?.data?.message ||
+          t("cancelApplicationModal.cancelError"),
+      );
+    } finally {
+      setCancellationLoading(false);
+    }
+  };
+
   const cancelLeave = () => {
     setShowModal(false);
+    setCancellationError("");
+    setCancellationSuccess("");
+
     if (blocker.state === "blocked") {
       blocker.reset();
     }
@@ -82,6 +139,9 @@ export default function LoanFlowWrapper() {
           <CancelApplicationModal
             onConfirm={confirmLeave}
             onCancel={cancelLeave}
+            loading={cancellationLoading}
+            error={cancellationError}
+            success={cancellationSuccess}
           />
         </div>
       )}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -368,7 +368,7 @@
   },
   "loanStep3": {
     "formTitle": "How would you like to repay this loan?",
-     "button": "Continue",
+    "button": "Continue",
     "repaymentOptions": {
       "RECYCLABLES": "Recyclables (e.g. plastics)",
       "CASH": "Cash",
@@ -453,7 +453,9 @@
     "title": "Cancel Application?",
     "body": "Are you sure you want to cancel? Any information you've entered so far will be lost.",
     "noButton": "No, go back",
-    "yesButton": "Yes, cancel"
+    "yesButton": "Yes, cancel",
+    "cancelSuccess": "Loan application cancelled successfully.",
+    "cancelError": "Unable to cancel the loan application. Please try again."
   },
   "repaymentsHistoryWrapper": {
     "noRepaymentData": "No repayment data found for this loan."

--- a/src/locales/ha.json
+++ b/src/locales/ha.json
@@ -453,7 +453,9 @@
     "title": "Soke Aikace-aikacen?",
     "body": "Ka tabbata kana son sokewa? Duk bayanan da ka shigar za su bace.",
     "noButton": "A'a, koma baya",
-    "yesButton": "Eh, soke"
+    "yesButton": "Eh, soke",
+    "cancelSuccess": "An soke aikace-aikacen rancen cikin nasara.",
+    "cancelError": "Ba a iya soke aikace-aikacen rancen ba. Don Allah a sake gwadawa."
   },
   "repaymentsHistoryWrapper": {
     "noRepaymentData": "Ba a sami bayanan biyan bashin wannan aron ba."


### PR DESCRIPTION
## Summary
- Add the pending-loan cancellation API request
- Cancel backend pending applications after explicit user confirmation
- Preserve the application when cancellation fails
- Refresh dashboard data after successful cancellation
- Display backend success and error messages in the confirmation modal
- Add localized fallback messages for English and Hausa
- Disable modal actions while cancellation is running

## Verification
- Production build passes
- Successful cancellation clears local form data and continues navigation
- Failed cancellation keeps the form intact and displays the backend message
- Applications without a backend pending loan still cancel locally