### PR TITLE
Handle expired authentication sessions

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,10 +1,13 @@
 import axios from "axios";
+import clearSessionData from "../utils/clearSessionData";
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 
 if (!apiBaseUrl) {
   throw new Error("VITE_API_BASE_URL is not configured");
 }
+
+let isHandlingUnauthorized = false;
 
 const instance = axios.create({
   baseURL: apiBaseUrl,
@@ -24,5 +27,24 @@ instance.interceptors.request.use((config) => {
 
   return config;
 });
+
+instance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const status = error.response?.status;
+    const hasToken = Boolean(localStorage.getItem("auth_token"));
+
+    if (status === 401 && hasToken && !isHandlingUnauthorized) {
+      isHandlingUnauthorized = true;
+
+      clearSessionData();
+      sessionStorage.setItem("sessionExpired", "true");
+
+      window.location.replace("/sign-in");
+    }
+
+    return Promise.reject(error);
+  },
+);
 
 export default instance;

--- a/src/components/auth/SignIn.jsx
+++ b/src/components/auth/SignIn.jsx
@@ -1,18 +1,36 @@
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 import * as yup from "yup";
+import { signIn } from "../../api/authApi";
 import BackgroundImage from "../BackgroundImage";
+import LoadingSpinner from "../LoadingSpinner";
 import WapfiLogo from "../WapfiLogo";
 import AuthFooter from "./AuthFooter";
-import { useTranslation } from "react-i18next";
-import { signIn } from "../../api/authApi";
-import LoadingSpinner from "../LoadingSpinner";
 
 function SignIn() {
+  const [sessionExpired, setSessionExpired] = useState(false);
   const [fadeIn, setFadeIn] = useState(false);
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const expired = sessionStorage.getItem("sessionExpired");
+
+    if (expired !== "true") {
+      return undefined;
+    }
+
+    setSessionExpired(true);
+
+    const timer = setTimeout(() => {
+      setSessionExpired(false);
+      sessionStorage.removeItem("sessionExpired");
+    }, 4000);
+
+    return () => clearTimeout(timer);
+  }, []);
 
   useEffect(() => {
     setFadeIn(true);
@@ -66,6 +84,8 @@ function SignIn() {
   }, [setValue]);
 
   const onSubmit = async (loginData) => {
+    setSessionExpired(false);
+    sessionStorage.removeItem("sessionExpired");
     setLoading(true);
 
     try {
@@ -137,6 +157,14 @@ function SignIn() {
                 {t("sign_in.login_prompt")}
               </p>
             </div>
+            {sessionExpired && (
+              <p
+                className="text-amber-700 bg-amber-50 border border-amber-200 rounded-lg p-3 mb-3"
+                role="alert"
+              >
+                {t("sign_in.session_expired")}
+              </p>
+            )}
 
             {showFormError && (
               <p className="text-red-500 mb-3">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -14,6 +14,7 @@
     "agree_terms": "By signing in, you agree to our",
     "terms_conditions": "Terms & Conditions",
     "privacy_policy": "Privacy Policy",
+    "session_expired": "Your session has expired. Please sign in again.",
 
     "placeholders": {
       "email_phone": "Enter your email address or phone number",

--- a/src/locales/ha.json
+++ b/src/locales/ha.json
@@ -14,6 +14,7 @@
     "agree_terms": "Ta hanyar shiga, kuna yarda da",
     "terms_conditions": "Sharuɗɗa & Ka'idoji",
     "privacy_policy": "Manufar Sirri",
+    "session_expired": "Zaman ku ya ƙare. Da fatan za ku sake shiga.",
 
     "placeholders": {
       "email_phone": "Shigar da imel ko lambar waya",

--- a/src/utils/clearSessionData.js
+++ b/src/utils/clearSessionData.js
@@ -1,0 +1,17 @@
+const sessionStorageKeys = [
+  "auth_token",
+  "dashboardData",
+  "loanConfirmationData",
+  "repaymentsData",
+  "disbursedLoansData",
+  "userData",
+  "loanApplicationDraft",
+  "latestLoanApplicationData",
+  "pendingLoanID",
+];
+
+export default function clearSessionData() {
+  sessionStorageKeys.forEach((key) => {
+    localStorage.removeItem(key);
+  });
+}


### PR DESCRIPTION
## Summary
- Add centralized handling for authenticated 401 responses
- Clear expired credentials and session-specific cached data
- Redirect expired sessions to the sign-in page
- Display a translated session-expiry message
- Automatically dismiss the expiry message

## Verification
- Production build passes
- Invalid or expired tokens redirect protected pages to sign-in
- The session-expiry message is displayed and automatically dismissed
- Protected pages no longer remain on an endless loader
- Invalid sign-in credentials continue to display the backend error
- English and Hausa messages are supported