### PR TITLE
Fix sign-in tablet layout

### DIFF
--- a/src/components/BackgroundImage.jsx
+++ b/src/components/BackgroundImage.jsx
@@ -6,17 +6,16 @@ function BackgroundImage() {
 
   return (
     <div
-      className="border hidden bg-cover rounded-3xl w-[669px] h-[890px] text-[#FFF] lg:flex lg:mr-3.5"
+      className="border hidden bg-cover bg-center rounded-3xl text-[#FFF] lg:flex lg:w-[46%] lg:max-w-[669px] lg:min-w-0 lg:h-[calc(100vh-5rem)] lg:min-h-[680px] lg:max-h-[890px] lg:flex-none"
       style={{ backgroundImage: `url(${bgImage})` }}
     >
       <div
-        className="w-[75%] py-[54px] px-[30px] mx-auto rounded-[12px] border border-[rgba(255,255,255,0.66)] 
-                bg-[rgba(255,255,255,0.45)] backdrop-blur-[18.25px] md:self-end md: mb-12"
+        className="w-[82%] p-6 mx-auto mb-12 self-end rounded-[12px] border border-[rgba(255,255,255,0.66)] bg-[rgba(255,255,255,0.45)] backdrop-blur-[18.25px] xl:w-[75%] xl:py-[54px] xl:px-[30px]"
       >
-        <p className="font-raleway font-bold text-[28px]">
+        <p className="font-raleway font-bold text-xl xl:text-[28px]">
            {t("background.headline")}
         </p>
-        <p className="text-[22px] font-heebo font-normal">
+        <p className="text-base font-heebo font-normal xl:text-[22px]">
           {t("background.subtext")}
         </p>
       </div>

--- a/src/components/auth/SignIn.jsx
+++ b/src/components/auth/SignIn.jsx
@@ -161,14 +161,14 @@ function SignIn() {
 
   return (
     <div
-      className={`w-full max-w-screen flex flex-col lg:flex-row justify-between lg:flex lg:justify-center lg:my-10 2xl:gap-10 transition-opacity duration-[2500ms] ease-in-out ${
+      className={`w-full max-w-[1440px] mx-auto flex flex-col lg:flex-row lg:items-stretch lg:justify-center lg:gap-6 lg:px-6 lg:my-10 xl:gap-10 transition-opacity duration-[2500ms] ease-in-out ${
         fadeIn ? "opacity-100" : "opacity-0"
       }`}
     >
       {/* <WapfiLogo /> */}
-      <div className="px-3">
+      <div className="px-3 lg:px-0 lg:w-[48%] lg:min-w-0 lg:max-w-[600px]">
         <WapfiLogo />
-        <div className="mx-auto flex flex-col items-center gap-[40px] w-full mb-12 max-w-[95%] md:text-[18px] md:max-w-[75%] lg:max-w-[511px] lg:gap-[40px] lg:self-center lg:mx-12 xl:mx-14 2xl:ml-32">
+        <div className="mx-auto flex flex-col items-center gap-[40px] w-full mb-12 max-w-[95%] md:text-[18px] md:max-w-[75%] lg:max-w-[511px] lg:w-full lg:px-4 lg:mx-auto lg:gap-[40px]">
           <form
             onSubmit={handleSubmit(onSubmit)}
             className="w-full flex flex-col gap-1 self-stretch md:text-[18px]"


### PR DESCRIPTION
## Summary

- Fixes the sign-in form and image overlapping at tablet widths.
- Uses proportional widths for the form and image columns.
- Preserves the existing desktop and mobile sign-in design.
- Adjusts the image overlay content for narrower tablet screens.

## Testing

- Verified iPad Pro portrait at 1024 × 1366.
- Verified iPad Pro landscape at 1366 × 1024.
- Confirmed there is no overlap or horizontal overflow.
- Confirmed `npm run build` completes successfully.