### PR TITLE
Add pending loan cancellation from overview

### DIFF
--- a/src/components/take a loan/CancelApplicationModal.jsx
+++ b/src/components/take a loan/CancelApplicationModal.jsx
@@ -1,13 +1,6 @@
 import { useTranslation } from "react-i18next";
-import LoadingSpinner from "../LoadingSpinner";
 
-export default function CancelApplicationModal({
-  onConfirm,
-  onCancel,
-  loading,
-  error,
-  success,
-}) {
+export default function CancelApplicationModal({ onConfirm, onCancel }) {
   const { t } = useTranslation();
 
   return (
@@ -18,39 +11,19 @@ export default function CancelApplicationModal({
       <p className="text-[rgba(68,68,68,0.80)]">
         {t("cancelApplicationModal.body")}
       </p>
-      {error && (
-        <p className="text-red-500 text-sm" role="alert">
-          {error}
-        </p>
-      )}
 
-      {success && (
-        <p className="text-green-600 text-sm" role="status">
-          {success}
-        </p>
-      )}
       <div className="flex items-center justify-center gap-6">
         <button
-          disabled={loading || Boolean(success)}
           onClick={onCancel}
-          className={`border border-[rgba(0,0,0,0.08)] font-medium rounded-[40px] bg-white py-2.5 px-6 hover:opacity-60 transition-opacity duration-300 ${
-            loading || success
-              ? "cursor-not-allowed opacity-60"
-              : "cursor-pointer"
-          }`}
+          className="border border-[rgba(0,0,0,0.08)] font-medium rounded-[40px] bg-white py-2.5 px-6 hover:opacity-60 transition-opacity duration-300 cursor-pointer"
         >
           {t("cancelApplicationModal.noButton")}
         </button>
         <button
-          disabled={loading || Boolean(success)}
           onClick={onConfirm}
-          className={`text-white bg-[#439182] font-medium border border-[rgba(0,0,0,0.08)] rounded-[40px] py-2.5 px-6 hover:opacity-80 transition-opacity duration-300 ${
-            loading || success
-              ? "cursor-not-allowed opacity-60"
-              : "cursor-pointer"
-          }`}
+          className="text-white bg-[#439182] font-medium border border-[rgba(0,0,0,0.08)] rounded-[40px] py-2.5 px-6 hover:opacity-80 transition-opacity duration-300 cursor-pointer"
         >
-          {loading ? <LoadingSpinner /> : t("cancelApplicationModal.yesButton")}
+          {t("cancelApplicationModal.yesButton")}
         </button>
       </div>
     </div>

--- a/src/components/take a loan/LoanFlowWrapper.jsx
+++ b/src/components/take a loan/LoanFlowWrapper.jsx
@@ -1,21 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { Outlet, useBlocker } from "react-router-dom";
-import { useDashboard } from "../../context/DashboardContext";
 import { useLoanForm } from "../../context/LoanFormContext";
 import CancelApplicationModal from "./CancelApplicationModal";
 import LoanFlowStepper from "./LoanFlowStepper";
-import { cancelPendingLoan } from "../../api/loansApi";
-import { useTranslation } from "react-i18next";
 
 export default function LoanFlowWrapper() {
-  const { t } = useTranslation();
-
-  const { dashboardData, refreshDashboardData } = useDashboard();
-
-  const [cancellationLoading, setCancellationLoading] = useState(false);
-  const [cancellationError, setCancellationError] = useState("");
-  const [cancellationSuccess, setCancellationSuccess] = useState("");
-
   const { clearLoanFormData, hasLoanFormData, hasUnsavedChanges } =
     useLoanForm();
 
@@ -69,7 +58,7 @@ export default function LoanFlowWrapper() {
     };
   }, [shouldWarnBeforeLeaving]);
 
-  const completeCancellation = () => {
+  const confirmLeave = () => {
     clearLoanFormData();
     setShowModal(false);
 
@@ -78,52 +67,8 @@ export default function LoanFlowWrapper() {
     }
   };
 
-  const confirmLeave = async () => {
-    const pendingLoanID = dashboardData?.pending_loan?._id;
-
-    setCancellationError("");
-    setCancellationSuccess("");
-
-    // Nothing exists on the backend yet.
-    if (!pendingLoanID) {
-      completeCancellation();
-      return;
-    }
-
-    setCancellationLoading(true);
-
-    try {
-      const response = await cancelPendingLoan(pendingLoanID);
-
-      if (response.status === 200 && response.data?.status) {
-        await refreshDashboardData();
-
-        setCancellationSuccess(
-          response.data?.message || t("cancelApplicationModal.cancelSuccess")
-        );
-
-        setTimeout(() => {
-          completeCancellation();
-        }, 1500);
-      } else {
-        setCancellationError(
-          response.data?.message || t("cancelApplicationModal.cancelError"),
-        );
-      }
-    } catch (error) {
-      setCancellationError(
-        error.response?.data?.message ||
-          t("cancelApplicationModal.cancelError"),
-      );
-    } finally {
-      setCancellationLoading(false);
-    }
-  };
-
   const cancelLeave = () => {
     setShowModal(false);
-    setCancellationError("");
-    setCancellationSuccess("");
 
     if (blocker.state === "blocked") {
       blocker.reset();
@@ -139,9 +84,6 @@ export default function LoanFlowWrapper() {
           <CancelApplicationModal
             onConfirm={confirmLeave}
             onCancel={cancelLeave}
-            loading={cancellationLoading}
-            error={cancellationError}
-            success={cancellationSuccess}
           />
         </div>
       )}

--- a/src/components/take a loan/LoanRepaymentOverview.jsx
+++ b/src/components/take a loan/LoanRepaymentOverview.jsx
@@ -1,16 +1,16 @@
-import BackArrow from "../../assets/back arrow.svg";
-import LoanApprovalModal from "./LoanApprovalModal";
-import { useTranslation } from "react-i18next";
-import LoadingSpinner from "../LoadingSpinner";
-import { useNavigate } from "react-router-dom";
-import { useState, useEffect } from "react";
-import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
 import * as yup from "yup";
-import { useLoanForm } from "../../context/LoanFormContext";
-import { confirmLoanApplication } from "../../api/loansApi";
+import { cancelPendingLoan, confirmLoanApplication } from "../../api/loansApi";
+import BackArrow from "../../assets/back arrow.svg";
 import { useDashboard } from "../../context/DashboardContext";
+import { useLoanForm } from "../../context/LoanFormContext";
 import { use_UserData } from "../../context/UserContext";
+import LoadingSpinner from "../LoadingSpinner";
+import LoanApprovalModal from "./LoanApprovalModal";
 
 export default function LoanRepaymentOverview() {
   const { t } = useTranslation();
@@ -45,6 +45,12 @@ export default function LoanRepaymentOverview() {
   const [showApprovalModal, setShowApprovalModal] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
 
+  const [cancelLoading, setCancelLoading] = useState(false);
+  const [cancelError, setCancelError] = useState("");
+  const [cancelSuccess, setCancelSuccess] = useState("");
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false);
+  const [loanCancelled, setLoanCancelled] = useState(false);
+
   // Form validation schema
   const schema = yup.object({
     password: yup
@@ -61,8 +67,10 @@ export default function LoanRepaymentOverview() {
 
   // Reconstruct loanFormData from pending loan and userData if empty
   useEffect(() => {
-    // Check a key which determines if loanFormData is empty or invalid
-    if (!loanFormData.loan_amount || loanFormData.loan_amount === "") {
+    if (
+      !loanCancelled &&
+      (!loanFormData.loan_amount || loanFormData.loan_amount === "")
+    ) {
       if (loanDetails) {
         const updatedFields = {
           loan_amount: loanDetails.loan_amount ?? "",
@@ -88,7 +96,7 @@ export default function LoanRepaymentOverview() {
         updateLoanFormData(updatedFields);
       }
     }
-  }, [loanDetails, loanFormData.loan_amount, updateLoanFormData, userData]);
+  }, [loanCancelled, loanDetails, loanFormData.loan_amount, updateLoanFormData, userData]);
 
   // Guard rendering until form data is ready
   if (!loanDetails || !isDataReady) {
@@ -112,7 +120,7 @@ export default function LoanRepaymentOverview() {
 
       const response = await confirmLoanApplication(
         loanIdToConfirm,
-        passwordData.password
+        passwordData.password,
       );
 
       if (response.status === 200) {
@@ -136,6 +144,47 @@ export default function LoanRepaymentOverview() {
     }
   };
 
+  const handleCancelPendingLoan = async () => {
+    const loanIdToCancel = loanDetails?._id;
+
+    if (!loanIdToCancel) {
+      setCancelError(t("loanRepaymentOverview.cancelMissingLoan"));
+      return;
+    }
+
+    setCancelLoading(true);
+    setCancelError("");
+    setCancelSuccess("");
+
+    try {
+      const response = await cancelPendingLoan(loanIdToCancel);
+
+      if (response.status === 200) {
+        setLoanCancelled(true);
+        clearLoanFormData();
+        localStorage.removeItem("pendingLoanID");
+        setShowCancelConfirm(false);
+        setCancelSuccess(
+          response.data?.message || t("loanRepaymentOverview.cancelSuccess"),
+        );
+
+        setTimeout(() => {
+          navigate("/dashboard");
+        }, 4000);
+      } else {
+        setCancelError(
+          response.data?.message || t("loanRepaymentOverview.cancelError"),
+        );
+      }
+    } catch (error) {
+      setCancelError(
+        error.response?.data?.message || t("loanRepaymentOverview.cancelError"),
+      );
+    } finally {
+      setCancelLoading(false);
+    }
+  };
+
   return (
     <>
       <div className="w-[95%] mx-auto md:w-[80%] flex flex-col gap-3 pb-12 lg:bg-white lg:mr-34 rounded-[12px] lg:p-6 lg:my-16 border-[rgba(0,0,0,0.08)]">
@@ -152,6 +201,18 @@ export default function LoanRepaymentOverview() {
               {t("loanRepaymentOverview.title")}
             </p>
           </div>
+
+          {cancelError && (
+            <p className="text-red-500 mb-3 text-center" role="alert">
+              {cancelError}
+            </p>
+          )}
+
+          {cancelSuccess && (
+            <p className="text-green-500 mb-3 text-center" role="status">
+              {cancelSuccess}
+            </p>
+          )}
 
           {formError && (
             <p className="text-red-500 mb-3 text-center">
@@ -308,6 +369,19 @@ export default function LoanRepaymentOverview() {
             >
               {loading ? <LoadingSpinner /> : t("loanRepaymentOverview.button")}
             </button>
+
+            <button
+              type="button"
+              disabled={loading || cancelLoading}
+              onClick={() => setShowCancelConfirm(true)}
+              className={`text-center w-full rounded-[50px] border border-red-500 text-red-500 my-2 font-medium py-3 px-3 hover:bg-red-50 transition-colors duration-300 ${
+                loading || cancelLoading
+                  ? "cursor-not-allowed opacity-60"
+                  : "cursor-pointer"
+              }`}
+            >
+              {t("loanRepaymentOverview.cancelButton")}
+            </button>
           </form>
         </div>
       </div>
@@ -315,6 +389,48 @@ export default function LoanRepaymentOverview() {
         <LoanApprovalModal
           data={loanDetails} // Pass loanDetails to the modal
         />
+      )}
+
+      {showCancelConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="w-full max-w-md rounded-[12px] bg-white p-6 shadow-lg">
+            <p className="text-xl font-raleway font-bold text-[#10172E]">
+              {t("loanRepaymentOverview.cancelModalTitle")}
+            </p>
+
+            <p className="mt-3 text-[#656565]">
+              {t("loanRepaymentOverview.cancelModalBody")}
+            </p>
+
+            <div className="mt-6 flex flex-col gap-3">
+              <button
+                type="button"
+                disabled={cancelLoading}
+                onClick={() => setShowCancelConfirm(false)}
+                className="w-full rounded-[50px] border border-[#439182] px-4 py-3 text-sm font-medium text-[#439182] hover:bg-[#439182]/10 sm:w-auto sm:min-w-[150px]"
+              >
+                {t("loanRepaymentOverview.cancelModalNo")}
+              </button>
+
+              <button
+                type="button"
+                disabled={cancelLoading}
+                onClick={handleCancelPendingLoan}
+                className={`w-full rounded-[50px] bg-red-500 px-4 py-3 text-sm font-medium text-white hover:opacity-80 sm:w-auto sm:min-w-[160px] ${
+                  cancelLoading
+                    ? "cursor-not-allowed opacity-60"
+                    : "cursor-pointer"
+                }`}
+              >
+                {cancelLoading ? (
+                  <LoadingSpinner />
+                ) : (
+                  t("loanRepaymentOverview.cancelModalYes")
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </>
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -445,7 +445,15 @@
     "passwordPlaceholder": "Enter your password",
     "passwordRequired": "Please enter your password",
     "passwordMin": "Password must be at least 8 characters",
-    "button": "Confirm and Receive Loan"
+    "button": "Confirm and Receive Loan",
+    "cancelButton": "Cancel Loan Application",
+    "cancelModalTitle": "Cancel Loan Application?",
+    "cancelModalBody": "Are you sure you want to cancel this loan application? This will cancel the pending application.",
+    "cancelModalNo": "Keep application",
+    "cancelModalYes": "Cancel application",
+    "cancelSuccess": "Loan application cancelled successfully.",
+    "cancelError": "Unable to cancel the loan application. Please try again.",
+    "cancelMissingLoan": "No pending loan application was found."
   },
   "loanApprovalModal": {
     "title": "Loan Approved & Sent!",
@@ -457,7 +465,7 @@
     "title": "Cancel Application?",
     "body": "Are you sure you want to cancel? Any information you've entered so far will be lost.",
     "noButton": "No, go back",
-    "yesButton": "Yes, cancel",
+    "yesButton": "Yes, clear form",
     "cancelSuccess": "Loan application cancelled successfully.",
     "cancelError": "Unable to cancel the loan application. Please try again."
   },

--- a/src/locales/ha.json
+++ b/src/locales/ha.json
@@ -445,7 +445,15 @@
     "passwordPlaceholder": "Shigar da kalmar sirri",
     "passwordRequired": "Don Allah a shigar da kalmar sirri.",
     "passwordMin": "Kalmar sirri dole ta kasance aƙalla haruffa 8.",
-    "button": "Tabbatar kuma Karɓi Lamuni"
+    "button": "Tabbatar kuma Karɓi Lamuni",
+    "cancelButton": "Soke Aikace-aikacen Lamuni",
+    "cancelModalTitle": "Soke Aikace-aikacen Lamuni?",
+    "cancelModalBody": "Kana da tabbacin kana son soke wannan aikace-aikacen lamuni? Wannan zai soke aikace-aikacen da ke jiran amincewa.",
+    "cancelModalNo": "Bar aikace-aikacen",
+    "cancelModalYes": "Soke aikace-aikacen",
+    "cancelSuccess": "An soke aikace-aikacen lamuni cikin nasara.",
+    "cancelError": "Ba a iya soke aikace-aikacen lamuni ba. Don Allah a sake gwadawa.",
+    "cancelMissingLoan": "Ba a sami aikace-aikacen lamuni da ke jiran amincewa ba."
   },
   "loanApprovalModal": {
     "title": "An Amince da Lamuni Kuma An Tura Shi!",
@@ -457,7 +465,7 @@
     "title": "Soke Aikace-aikacen?",
     "body": "Ka tabbata kana son sokewa? Duk bayanan da ka shigar za su bace.",
     "noButton": "A'a, koma baya",
-    "yesButton": "Eh, soke",
+    "yesButton": "Eh, share fom",
     "cancelSuccess": "An soke aikace-aikacen rancen cikin nasara.",
     "cancelError": "Ba a iya soke aikace-aikacen rancen ba. Don Allah a sake gwadawa."
   },


### PR DESCRIPTION
## Summary

- Adds a cancel action to the loan repayment overview page for pending loan applications.
- Calls the backend pending-loan cancellation endpoint from the overview page.
- Shows loading, success, and error states during cancellation.
- Clears local loan form data after successful cancellation.
- Simplifies the loan step warning modal so it only clears local form data when leaving steps 1-4.
- Adds English and Hausa translations for the new cancellation UI.

## Testing

- Confirmed pending loan cancellation succeeds from the loan repayment overview page.
- Confirmed backend success/error messages are shown with frontend fallbacks.
- Confirmed local loan form data is cleared after cancellation.
- Confirmed leaving loan steps 1-4 clears local form data only.