### PR TITLE
Fix/loan verification spinner

### DIFF
--- a/src/components/take a loan/EnterBVN.jsx
+++ b/src/components/take a loan/EnterBVN.jsx
@@ -1,13 +1,13 @@
-import { useState, useEffect } from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import * as yup from "yup";
 import { useTranslation } from "react-i18next";
-import LoadingSpinner from "../LoadingSpinner";
 import { useNavigate } from "react-router-dom";
+import * as yup from "yup";
 import { verifyIdentity } from "../../api/apiData";
-import { use_UserData } from "../../context/UserContext";
 import { useNotifications } from "../../context/NotificationContext";
+import { use_UserData } from "../../context/UserContext";
+import LoadingSpinner from "../LoadingSpinner";
 
 export default function EnterBVN() {
   const navigate = useNavigate();
@@ -49,7 +49,7 @@ export default function EnterBVN() {
         // refresh user data to make sure we get the latest data
         await refreshUserData();
         setShowSuccessMessage(response.data?.message);
-
+        setLoading(false);
         await refreshNotificationsCount();
 
         setTimeout(() => {
@@ -101,9 +101,11 @@ export default function EnterBVN() {
           )}
 
           <button
-            disabled={loading}
+            disabled={loading || Boolean(showSuccessMessage)}
             className={`text-center w-full py-3 px-2.5 gap-2.5 rounded-[50px] text-[#FFF] font-medium bg-[#439182] mt-10 hover:opacity-80 transition-opacity duration-300 ${
-              loading ? "duration-300 cursor-not-allowed" : "cursor-pointer"
+              loading || showSuccessMessage
+                ? "duration-300 cursor-not-allowed"
+                : "cursor-pointer"
             }`}
           >
             {loading ? <LoadingSpinner /> : t("bvn.cta")}

--- a/src/components/take a loan/VerifyPhoneNumber.jsx
+++ b/src/components/take a loan/VerifyPhoneNumber.jsx
@@ -237,7 +237,7 @@ export default function VerifyPhoneNumber() {
           />
         </div>
         <button
-          disabled={loading || Boolean(showSuccessMessage)}
+          disabled={loading || Boolean(showVerificationSuccess)}
           type="submit"
           className={`text-center w-full my-6 rounded-[50px] text-[#FFF] font-medium bg-[#439182] py-3 px-3 hover:opacity-80 transition-opacity duration-300 ${
             loading || showVerificationSuccess

--- a/src/components/take a loan/VerifyPhoneNumber.jsx
+++ b/src/components/take a loan/VerifyPhoneNumber.jsx
@@ -1,23 +1,20 @@
-
-
-import arrowTimer from "../../assets/arrow-timer.svg";
-import { useState, useEffect, useRef } from "react";
 import { yupResolver } from "@hookform/resolvers/yup";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
-import * as yup from "yup";
 import { useTranslation } from "react-i18next";
-import LoadingSpinner from "../LoadingSpinner";
 import { useNavigate } from "react-router-dom";
+import * as yup from "yup";
 import { verifyIdentity } from "../../api/apiData";
-import { use_UserData } from "../../context/UserContext";
+import arrowTimer from "../../assets/arrow-timer.svg";
 import { useNotifications } from "../../context/NotificationContext";
+import { use_UserData } from "../../context/UserContext";
+import LoadingSpinner from "../LoadingSpinner";
 
 export default function VerifyPhoneNumber() {
   const [fadeIn, setFadeIn] = useState(false);
   const [loading, setLoading] = useState(false);
   const { userData, refreshUserData } = use_UserData();
   const { refreshNotificationsCount } = useNotifications();
-
 
   // Refs for inputs
   const firstRef = useRef(null);
@@ -100,8 +97,9 @@ export default function VerifyPhoneNumber() {
 
       if (response.status) {
         setShowVerificationSuccess(response.data?.message);
+        setLoading(false);
         await refreshNotificationsCount();
-        
+
         // refresh user data to make sure we get the latest data
         const updatedUserData = await refreshUserData();
 
@@ -180,7 +178,9 @@ export default function VerifyPhoneNumber() {
           )}
 
           {showVerificationSuccess && (
-            <p className="text-green-500 mb-3">{showVerificationSuccess || t("verifyPhone.success")}</p>
+            <p className="text-green-500 mb-3">
+              {showVerificationSuccess || t("verifyPhone.success")}
+            </p>
           )}
 
           {showResendSuccess && (
@@ -237,10 +237,12 @@ export default function VerifyPhoneNumber() {
           />
         </div>
         <button
-          disabled={loading}
+          disabled={loading || Boolean(showSuccessMessage)}
           type="submit"
           className={`text-center w-full my-6 rounded-[50px] text-[#FFF] font-medium bg-[#439182] py-3 px-3 hover:opacity-80 transition-opacity duration-300 ${
-            loading ? "duration-300 cursor-not-allowed" : "cursor-pointer"
+            loading || showVerificationSuccess
+              ? "duration-300 cursor-not-allowed"
+              : "cursor-pointer"
           }`}
         >
           {loading ? <LoadingSpinner /> : t("verifyPhone.continue")}


### PR DESCRIPTION
## Summary

- Stops the BVN verification spinner once verification succeeds.
- Stops the phone verification spinner once verification succeeds.
- Keeps the submit buttons disabled while success messages are visible to prevent duplicate submissions before navigation.

## Testing

- Tested successful BVN verification.
- Tested successful phone verification.
- Confirmed success messages show without the button spinner continuing.
- Confirmed submit buttons remain disabled while waiting for navigation.