### PR TITLE
Redirect verified BVN users to phone verification

### DIFF
--- a/src/components/take a loan/EnterBVN.jsx
+++ b/src/components/take a loan/EnterBVN.jsx
@@ -19,11 +19,17 @@ export default function EnterBVN() {
   const [showSuccessMessage, setShowSuccessMessage] = useState("");
   const { refreshNotificationsCount } = useNotifications();
 
-  const { refreshUserData } = use_UserData();
+  const { refreshUserData, userData } = use_UserData();
 
   useEffect(() => {
     setFadeIn(true);
   }, []);
+
+  useEffect(() => {
+    if (userData?.bvn_verified && !userData?.phone_verified) {
+      navigate("/take-a-loan/verify-phone");
+    }
+  }, [userData?.bvn_verified, userData?.phone_verified, navigate]);
 
   const schema = yup.object({
     bvn: yup
@@ -60,6 +66,13 @@ export default function EnterBVN() {
       }
     } catch (error) {
       setFormError(error.response?.data?.message);
+      const freshUserData = await refreshUserData();
+
+      if (freshUserData?.bvn_verified && !freshUserData?.phone_verified) {
+        setTimeout(() => {
+          navigate("/take-a-loan/verify-phone");
+        }, 2500);
+      }
     } finally {
       setLoading(false);
       setTimeout(() => {


### PR DESCRIPTION
## Summary

- Redirects users with an already verified BVN to phone verification.
- Handles the “BVN already verified” backend response by refreshing user data and moving the user forward.
- Prevents users from getting stuck on the BVN page after going back from phone verification.

## Testing

- Tested BVN verification success flow.
- Tested returning to the BVN page after BVN was already verified.
- Confirmed users are redirected to phone verification when `bvn_verified` is true and `phone_verified` is false.