### PR TITLE
Support six digit password reset codes

### DIFF
--- a/src/components/auth/ChangePassword.jsx
+++ b/src/components/auth/ChangePassword.jsx
@@ -55,6 +55,7 @@ function ChangePassword() {
     }
     try {
       const response = await resetPassword({
+        identifier: localStorage.getItem("userIdentifier"),
         code: localStorage.getItem("otpCode"),
         new_password: passwordData.newPassword,
       });
@@ -66,6 +67,7 @@ function ChangePassword() {
         reset();
 
         localStorage.removeItem("otpCode");
+        localStorage.removeItem("userIdentifier");
         // navigate to sign in page
         setTimeout(() => {
           navigate("/sign-in");

--- a/src/components/auth/VerifyPhoneEmail.jsx
+++ b/src/components/auth/VerifyPhoneEmail.jsx
@@ -1,14 +1,14 @@
-import arrowTimer from "../../assets/arrow-timer.svg";
-import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
-import * as yup from "yup";
-import { useEffect, useState, useRef } from "react";
-import WapfiLogo from "../WapfiLogo";
-import LoadingSpinner from "../LoadingSpinner";
-import BackgroundImage from "../BackgroundImage";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import * as yup from "yup";
 import { requestPasswordReset, verifyResetCode } from "../../api/authApi";
+import arrowTimer from "../../assets/arrow-timer.svg";
+import BackgroundImage from "../BackgroundImage";
+import LoadingSpinner from "../LoadingSpinner";
+import WapfiLogo from "../WapfiLogo";
 
 function VerifyPhoneEmail() {
   const [fadeIn, setFadeIn] = useState(false);
@@ -19,6 +19,8 @@ function VerifyPhoneEmail() {
   const secondRef = useRef(null);
   const thirdRef = useRef(null);
   const fourthRef = useRef(null);
+  const fifthRef = useRef(null);
+  const sixthRef = useRef(null);
 
   useEffect(() => {
     setFadeIn(true);
@@ -59,6 +61,20 @@ function VerifyPhoneEmail() {
       .test("is-digit", t("verify.errors.invalid_digit"), (value) => {
         return /^\d{1}$/.test(value);
       }),
+
+    fifthDigit: yup
+      .string()
+      .required(t("verify.errors.digit_required"))
+      .test("is-digit", t("verify.errors.invalid_digit"), (value) => {
+        return /^\d{1}$/.test(value);
+      }),
+
+    sixthDigit: yup
+      .string()
+      .required(t("verify.errors.digit_required"))
+      .test("is-digit", t("verify.errors.invalid_digit"), (value) => {
+        return /^\d{1}$/.test(value);
+      }),
   });
 
   const [showFormError, setShowFormError] = useState("");
@@ -94,7 +110,9 @@ function VerifyPhoneEmail() {
       otpCode.firstDigit +
       otpCode.secondDigit +
       otpCode.thirdDigit +
-      otpCode.fourthDigit;
+      otpCode.fourthDigit +
+      otpCode.fifthDigit +
+      otpCode.sixthDigit;
 
     try {
       const response = await verifyResetCode(code);
@@ -103,8 +121,6 @@ function VerifyPhoneEmail() {
         localStorage.setItem("otpCode", code);
 
         setShowVerificationSuccess(response.data?.message);
-
-        localStorage.removeItem("userIdentifier");
 
         setTimeout(() => {
           navigate("/change-password");
@@ -216,7 +232,7 @@ function VerifyPhoneEmail() {
               </button>
             </div>
 
-            <div className="w-[263px] flex justify-center items-center gap-3 mx-auto -mt-2.5 text-[rgba(34,34,34,0.50)]">
+            <div className="w-full flex justify-center items-center gap-2 mx-auto -mt-2.5 text-[rgba(34,34,34,0.50)] sm:gap-3">
               <input
                 type="text"
                 maxLength={1}
@@ -252,8 +268,28 @@ function VerifyPhoneEmail() {
                 maxLength={1}
                 {...register("fourthDigit")}
                 ref={mergeRefs(register("fourthDigit").ref, fourthRef)}
-                onChange={(e) => handleInput(e, null, thirdRef)}
-                onKeyDown={(e) => handleInput(e, null, thirdRef)}
+                onChange={(e) => handleInput(e, fifthRef, thirdRef)}
+                onKeyDown={(e) => handleInput(e, fifthRef, thirdRef)}
+                className="text-center w-[50px] h-[50px] border p-3.5 rounded-[8px] border-[rgba(0,0,0,0.15)]"
+              />
+
+              <input
+                type="text"
+                maxLength={1}
+                {...register("fifthDigit")}
+                ref={mergeRefs(register("fifthDigit").ref, fifthRef)}
+                onChange={(e) => handleInput(e, sixthRef, fourthRef)}
+                onKeyDown={(e) => handleInput(e, sixthRef, fourthRef)}
+                className="text-center w-[50px] h-[50px] border p-3.5 rounded-[8px] border-[rgba(0,0,0,0.15)]"
+              />
+
+              <input
+                type="text"
+                maxLength={1}
+                {...register("sixthDigit")}
+                ref={mergeRefs(register("sixthDigit").ref, sixthRef)}
+                onChange={(e) => handleInput(e, null, fifthRef)}
+                onKeyDown={(e) => handleInput(e, null, fifthRef)}
                 className="text-center w-[50px] h-[50px] border p-3.5 rounded-[8px] border-[rgba(0,0,0,0.15)]"
               />
             </div>

--- a/src/components/settings/PasswordResetForm.jsx
+++ b/src/components/settings/PasswordResetForm.jsx
@@ -1,10 +1,10 @@
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import * as yup from "yup";
-import LoadingSpinner from "../LoadingSpinner";
 import { resetPassword } from "../../api/authApi";
+import LoadingSpinner from "../LoadingSpinner";
 
 export default function PasswordResetForm() {
   const [loading, setLoading] = useState(false);
@@ -33,8 +33,19 @@ export default function PasswordResetForm() {
     register,
     handleSubmit,
     reset,
+    watch,
+    trigger,
     formState: { errors },
   } = useForm({ mode: "onChange", resolver: yupResolver(schema) });
+
+  const newPassword = watch("newPassword");
+  const confirmedPassword = watch("confirmedPassword");
+
+  useEffect(() => {
+    if (confirmedPassword) {
+      trigger("confirmedPassword");
+    }
+  }, [newPassword, confirmedPassword, trigger]);
 
   const onSubmit = async (passwordData) => {
     setLoading(true);
@@ -48,6 +59,7 @@ export default function PasswordResetForm() {
       // get otp code
       const otp = localStorage.getItem("otpCode");
       const response = await resetPassword({
+        identifier: localStorage.getItem("userIdentifier"),
         code: otp,
         new_password: passwordData.newPassword,
       });
@@ -57,6 +69,7 @@ export default function PasswordResetForm() {
 
         // now remove otp code
         localStorage.removeItem("otpCode");
+        localStorage.removeItem("userIdentifier");
         reset();
       } else {
         setShowFormError(response.data?.message);

--- a/src/components/settings/SettingsVerifyEmailPhone.jsx
+++ b/src/components/settings/SettingsVerifyEmailPhone.jsx
@@ -1,12 +1,12 @@
-import arrowTimer from "../../assets/arrow-timer.svg";
-import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
-import * as yup from "yup";
-import { useEffect, useState, useRef } from "react";
-import LoadingSpinner from "../LoadingSpinner";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import * as yup from "yup";
 import { requestPasswordReset, verifyResetCode } from "../../api/authApi";
+import arrowTimer from "../../assets/arrow-timer.svg";
+import LoadingSpinner from "../LoadingSpinner";
 
 export default function SettingsVerifyEmailPhone() {
   const [loading, setLoading] = useState(false);
@@ -16,6 +16,8 @@ export default function SettingsVerifyEmailPhone() {
   const secondRef = useRef(null);
   const thirdRef = useRef(null);
   const fourthRef = useRef(null);
+  const fifthRef = useRef(null);
+  const sixthRef = useRef(null);
 
   useEffect(() => {
     // Focus the first input on mount
@@ -50,6 +52,20 @@ export default function SettingsVerifyEmailPhone() {
       }),
 
     fourthDigit: yup
+      .string()
+      .required(t("settingsVerify.errors.digit_required"))
+      .test("is-digit", t("settingsVerify.errors.invalid_digit"), (value) => {
+        return /^\d{1}$/.test(value);
+      }),
+
+    fifthDigit: yup
+      .string()
+      .required(t("settingsVerify.errors.digit_required"))
+      .test("is-digit", t("settingsVerify.errors.invalid_digit"), (value) => {
+        return /^\d{1}$/.test(value);
+      }),
+
+    sixthDigit: yup
       .string()
       .required(t("settingsVerify.errors.digit_required"))
       .test("is-digit", t("settingsVerify.errors.invalid_digit"), (value) => {
@@ -98,7 +114,9 @@ export default function SettingsVerifyEmailPhone() {
       otpCode.firstDigit +
       otpCode.secondDigit +
       otpCode.thirdDigit +
-      otpCode.fourthDigit;
+      otpCode.fourthDigit +
+      otpCode.fifthDigit +
+      otpCode.sixthDigit;
 
     try {
       const response = await verifyResetCode(code);
@@ -113,8 +131,6 @@ export default function SettingsVerifyEmailPhone() {
       } else {
         setShowFormError(response.data?.message);
       }
-
-      localStorage.removeItem("userIdentifier");
     } catch (error) {
       setShowFormError(error.response?.data?.message);
     } finally {
@@ -246,8 +262,28 @@ export default function SettingsVerifyEmailPhone() {
             maxLength={1}
             {...register("fourthDigit")}
             ref={mergeRefs(register("fourthDigit").ref, fourthRef)}
-            onChange={(e) => handleInput(e, null, thirdRef)}
-            onKeyDown={(e) => handleInput(e, null, thirdRef)}
+            onChange={(e) => handleInput(e, fifthRef, thirdRef)}
+            onKeyDown={(e) => handleInput(e, fifthRef, thirdRef)}
+            className="text-center w-[50px] h-[50px] border p-3.5 rounded-[8px] border-[rgba(0,0,0,0.15)]"
+          />
+
+          <input
+            type="text"
+            maxLength={1}
+            {...register("fifthDigit")}
+            ref={mergeRefs(register("fifthDigit").ref, fifthRef)}
+            onChange={(e) => handleInput(e, sixthRef, fourthRef)}
+            onKeyDown={(e) => handleInput(e, sixthRef, fourthRef)}
+            className="text-center w-[50px] h-[50px] border p-3.5 rounded-[8px] border-[rgba(0,0,0,0.15)]"
+          />
+
+          <input
+            type="text"
+            maxLength={1}
+            {...register("sixthDigit")}
+            ref={mergeRefs(register("sixthDigit").ref, sixthRef)}
+            onChange={(e) => handleInput(e, null, fifthRef)}
+            onKeyDown={(e) => handleInput(e, null, fifthRef)}
             className="text-center w-[50px] h-[50px] border p-3.5 rounded-[8px] border-[rgba(0,0,0,0.15)]"
           />
         </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -62,7 +62,7 @@
   },
   "change_password": {
     "title": "Change Password",
-    "subtext": "Enter your current password and set a new one to keep your account secure",
+    "subtext": "Set a new password to regain access to your account.",
     "success": "Password changed successfully!",
     "general_error": "Please complete all fields correctly to update your password.",
     "new": "New Password",
@@ -79,7 +79,7 @@
   },
   "forgot_password": {
     "title": "Forgot Password",
-    "subtext": "We'll send you a 4-digit code to your email or phone number to verify your identity and help you reset your password.",
+    "subtext": "We'll send you a 6-digit code to your email or phone number to verify your identity and help you reset your password.",
     "error": "We couldn't send the code. Please make sure your email or phone number is correct.",
     "success": "Verification code sent successfully!",
     "email_or_phone": "Email or Phone Number",
@@ -94,7 +94,7 @@
   },
   "verify": {
     "title": "Verify Your Email or Phone Number",
-    "subtext": "Please enter the 4-digit code sent to your email or phone number.",
+    "subtext": "Please enter the 6-digit code sent to your email or phone number.",
     "error": "The code you entered is incorrect. Please try again.",
     "success": "Code verified successfully!",
     "continue": "Continue",
@@ -609,7 +609,7 @@
 
   "settingsVerify": {
     "title": "Verify Your Email Address or Phone Number",
-    "subtext": "We’ve sent a 4-digit code to your email or phone. Please enter it below to verify your account.",
+    "subtext": "We’ve sent a 6-digit code to your email or phone. Please enter it below to verify your account.",
     "continue": "Continue",
     "resend": "Resend code",
     "resend_in": "Resend code in",

--- a/src/locales/ha.json
+++ b/src/locales/ha.json
@@ -62,7 +62,7 @@
   },
   "change_password": {
     "title": "Canza Kalmar Sirri",
-    "subtext": "Shigar da kalmar sirri ta yanzu kuma saita sabuwa don kiyaye asusunka lafiya",
+    "subtext": "Saita sabuwar kalmar sirri domin sake samun damar shiga asusunka.",
     "success": "An canza kalmar sirri cikin nasara!",
     "general_error": "Da fatan a cika duka filayen daidai don sabunta kalmar sirri.",
     "new": "Sabuwar Kalmar Sirri",
@@ -79,7 +79,7 @@
   },
   "forgot_password": {
     "title": "Ka manta kalmar sirri?",
-    "subtext": "Za mu aiko maka da lamba guda huɗu zuwa imel ko lambar wayarka domin tantance kai da kuma taimaka maka ka saita sabuwar kalmar sirri.",
+    "subtext": "Za mu aiko maka da lamba mai lambobi shida zuwa imel ko lambar wayarka domin tantance kai da taimaka maka saita sabuwar kalmar sirri.",
     "error": "Ba za mu iya aika lamban ba. Da fatan a tabbatar da cewa imel ko lambar waya ya dace.",
     "success": "An aika da lambobin tabbatarwa cikin nasara!",
     "email_or_phone": "Imel ko Lambar waya",
@@ -94,7 +94,7 @@
   },
   "verify": {
     "title": "Tabbatar da Imel ko Lambar Waya",
-    "subtext": "Da fatan za a shigar da lambobi huɗu da aka aiko zuwa imel ko lambar wayarka.",
+    "subtext": "Da fatan za a shigar da lamba mai lambobi shida da aka aika zuwa imel ko lambar wayarka.",
     "error": "Lambobin da ka shigar ba daidai bane. Da fatan a sake gwadawa.",
     "success": "An tabbatar da lambar cikin nasara!",
     "continue": "Ci gaba",
@@ -608,7 +608,7 @@
 
   "settingsVerify": {
     "title": "Tabbatar da Imel ko Lambar Wayarka",
-    "subtext": "Mun aiko lambar lambobi 4 zuwa imel ko wayarka. Da fatan za a shigar da ita don tabbatar da asusunka.",
+    "subtext": "Mun aika maka da lamba mai lambobi shida zuwa imel ko lambar wayarka. Da fatan za a shigar da ita a ƙasa domin tabbatar da asusunka.",
     "continue": "Ci gaba",
     "resend": "Aiko lamba karo na biyu",
     "resend_in": "Aiko lamba a cikin",


### PR DESCRIPTION
## Summary

- Updates password reset verification to support 6-digit codes.
- Updates both forgot-password and settings reset-code flows.
- Keeps the email/phone identifier until password reset succeeds.
- Sends identifier, code, and new password to the reset endpoint.
- Updates English and Hausa reset-code copy.

## Testing

- Tested forgot-password reset with a 6-digit code.
- Tested settings password reset with a 6-digit code.
- Confirmed all six digits are submitted.
- Confirmed password reset succeeds after code verification.
- Confirmed `npm run build` completes successfully.