### PR TITLE
Validate Nigerian phone identifiers in auth forms

### DIFF
--- a/src/components/auth/ForgotPassword.jsx
+++ b/src/components/auth/ForgotPassword.jsx
@@ -4,10 +4,10 @@ import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import * as yup from "yup";
-import BackgroundImage from "../BackgroundImage";
-import WapfiLogo from "../WapfiLogo";
 import { requestPasswordReset } from "../../api/authApi";
+import BackgroundImage from "../BackgroundImage";
 import LoadingSpinner from "../LoadingSpinner";
+import WapfiLogo from "../WapfiLogo";
 
 function ForgotPassword() {
   const [fadeIn, setFadeIn] = useState(false);
@@ -35,7 +35,8 @@ function ForgotPassword() {
         t("forgot_password.errors.invalid_email_or_phone"),
         (value) => {
           return (
-            /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) || /^\d{11}$/.test(value)
+            /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) ||
+            /^0(?:70|80|81|90|91)\d{8}$/.test(value)
           );
         },
       ),

--- a/src/components/auth/SignIn.jsx
+++ b/src/components/auth/SignIn.jsx
@@ -77,7 +77,8 @@ function SignIn() {
         t("sign_in.errors.invalid_email_or_phone"),
         (value) => {
           return (
-            /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) || /^\d{11}$/.test(value)
+            /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) ||
+            /^0(?:70|80|81|90|91)\d{8}$/.test(value)
           );
         },
       ),

--- a/src/components/auth/SignUpAccountVerification.jsx
+++ b/src/components/auth/SignUpAccountVerification.jsx
@@ -50,7 +50,8 @@ function SignUpAccountVerification() {
         t("sign_up.errors.invalid_email_or_phone"),
         (value) => {
           return (
-            /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) || /^\d{11}$/.test(value)
+            /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) ||
+            /^0(?:70|80|81|90|91)\d{8}$/.test(value)
           );
         },
       ),

--- a/src/components/settings/SettingsForgotPassword.jsx
+++ b/src/components/settings/SettingsForgotPassword.jsx
@@ -28,7 +28,8 @@ export default function ForgotPassword() {
         t("settingsForgotPassword.errors.invalid_email_or_phone"),
         (value) => {
           return (
-            /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) || /^\d{11}$/.test(value)
+            /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) ||
+            /^0(?:70|80|81|90|91)\d{8}$/.test(value)
           );
         },
       ),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -23,7 +23,7 @@
 
     "errors": {
       "email_or_phone_required": "Please enter your email or phone number",
-      "invalid_email_or_phone": "Invalid email or phone number",
+      "invalid_email_or_phone": "Please enter a valid email or Nigerian phone number, e.g. 08012345678.",
       "password_required": "Please enter your password",
       "password_min": "Password must be at least 8 characters"
     }
@@ -48,7 +48,7 @@
       "full_name_required": "Please enter your full name",
       "full_name_invalid": "Invalid full name",
       "email_or_phone_required": "Please enter your email or phone number",
-      "invalid_email_or_phone": "Invalid email or phone number",
+      "invalid_email_or_phone": "Please enter a valid email or Nigerian phone number, e.g. 08012345678.",
       "password_required": "Please enter your password",
       "password_min": "Password must be at least 8 characters",
       "passwords_do_not_match": "Passwords do not match. Please try again."
@@ -86,7 +86,7 @@
     "continue": "Continue",
     "errors": {
       "email_or_phone_required": "Please enter your email or phone number",
-      "invalid_email_or_phone": "Invalid email or phone number"
+      "invalid_email_or_phone": "Please enter a valid email or Nigerian phone number, e.g. 08012345678."
     },
     "placeholders": {
       "email_phone": "Enter your email address or phone number"
@@ -603,7 +603,7 @@
     "success": "A reset code has been sent to your email or phone.",
     "errors": {
       "email_or_phone_required": "Email or phone number is required.",
-      "invalid_email_or_phone": "Please enter a valid email or 11-digit phone number."
+      "invalid_email_or_phone": "Please enter a valid email or Nigerian phone number, e.g. 08012345678."
     }
   },
 

--- a/src/locales/ha.json
+++ b/src/locales/ha.json
@@ -23,7 +23,7 @@
 
     "errors": {
       "email_or_phone_required": "Da fatan za a shigar da imel ko lambar waya",
-      "invalid_email_or_phone": "Imel ko lambar waya bai dace ba",
+      "invalid_email_or_phone": "Da fatan za a shigar da imel mai inganci ko lambar wayar Najeriya.",
       "password_required": "Da fatan za a shigar da kalmar sirri",
       "password_min": "Kalmar sirri dole ta kasance aƙalla haruffa 8"
     }
@@ -48,7 +48,7 @@
       "full_name_required": "Da fatan a shigar da cikakken suna",
       "full_name_invalid": "Cikakken suna bai dace ba",
       "email_or_phone_required": "Da fatan za a shigar da imel ko lambar waya",
-      "invalid_email_or_phone": "Imel ko lambar waya bai dace ba",
+      "invalid_email_or_phone": "Da fatan za a shigar da imel mai inganci ko lambar wayar Najeriya.",
       "password_required": "Da fatan za a shigar da kalmar sirri",
       "password_min": "Kalmar sirri dole ta kasance aƙalla haruffa 8",
       "passwords_do_not_match": "Kalmar sirri da aka tabbatar ba su dace ba. Don Allah a sake gwadawa."
@@ -86,7 +86,7 @@
     "continue": "Ci gaba",
     "errors": {
       "email_or_phone_required": "Da fatan za a shigar da imel ko lambar waya",
-      "invalid_email_or_phone": "Imel ko lambar waya bai dace ba"
+      "invalid_email_or_phone": "Da fatan za a shigar da imel mai inganci ko lambar wayar Najeriya."
     },
     "placeholders": {
       "email_phone": "Shigar da imel ko lambar waya"
@@ -602,7 +602,7 @@
     "success": "An aiko da lambar sauya kalmar sirri zuwa imel ko wayarka.",
     "errors": {
       "email_or_phone_required": "Dole ne a shigar da imel ko lambar waya.",
-      "invalid_email_or_phone": "Da fatan za a shigar da imel mai inganci ko lambar waya guda 11."
+      "invalid_email_or_phone": "Da fatan za a shigar da imel mai inganci ko lambar wayar Najeriya."
     }
   },
 


### PR DESCRIPTION
## Summary

- Updates auth identifier validation to support Nigerian phone numbers.
- Accepts local format such as `08012345678`.
- Keeps email identifier support unchanged.
- Updates English and Hausa validation messages for clearer phone-number guidance.

## Testing

- Tested valid Nigerian phone formats.
- Tested invalid/non-Nigerian phone numbers.
- Tested email identifier validation still works.
- Confirmed `npm run build` completes successfully.