### PR TITLE
Handle missing pending loan overview state

### DIFF
--- a/src/components/take a loan/LoanRepaymentOverview.jsx
+++ b/src/components/take a loan/LoanRepaymentOverview.jsx
@@ -96,11 +96,40 @@ export default function LoanRepaymentOverview() {
         updateLoanFormData(updatedFields);
       }
     }
-  }, [loanCancelled, loanDetails, loanFormData.loan_amount, updateLoanFormData, userData]);
+  }, [
+    loanCancelled,
+    loanDetails,
+    loanFormData.loan_amount,
+    updateLoanFormData,
+    userData,
+  ]);
 
   // Guard rendering until form data is ready
-  if (!loanDetails || !isDataReady) {
+  // if (!loanDetails || !isDataReady) {
+  //   return <LoadingSpinner />;
+  // }
+  if (!isDataReady) {
     return <LoadingSpinner />;
+  }
+
+  if (!loanDetails) {
+    return (
+      <div className="w-[95%] mx-auto md:w-[80%] flex flex-col items-center gap-4 rounded-[12px] bg-white p-6 text-center lg:my-16">
+        <p className="text-[24px] font-raleway font-bold text-[#10172E]">
+          {t("loanRepaymentOverview.noPendingTitle")}
+        </p>
+        <p className="text-[#656565]">
+          {t("loanRepaymentOverview.noPendingBody")}
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate("/dashboard")}
+          className="mt-2 rounded-[50px] bg-[#439182] px-6 py-3 font-medium text-white hover:opacity-80"
+        >
+          {t("loanRepaymentOverview.noPendingButton")}
+        </button>
+      </div>
+    );
   }
 
   const handleBackArrowClick = () => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -453,7 +453,10 @@
     "cancelModalYes": "Cancel application",
     "cancelSuccess": "Loan application cancelled successfully.",
     "cancelError": "Unable to cancel the loan application. Please try again.",
-    "cancelMissingLoan": "No pending loan application was found."
+    "cancelMissingLoan": "No pending loan application was found.",
+    "noPendingTitle": "No pending loan application",
+    "noPendingBody": "You do not have a pending loan application to review.",
+    "noPendingButton": "Back to dashboard"
   },
   "loanApprovalModal": {
     "title": "Loan Approved & Sent!",

--- a/src/locales/ha.json
+++ b/src/locales/ha.json
@@ -453,7 +453,10 @@
     "cancelModalYes": "Soke aikace-aikacen",
     "cancelSuccess": "An soke aikace-aikacen lamuni cikin nasara.",
     "cancelError": "Ba a iya soke aikace-aikacen lamuni ba. Don Allah a sake gwadawa.",
-    "cancelMissingLoan": "Ba a sami aikace-aikacen lamuni da ke jiran amincewa ba."
+    "cancelMissingLoan": "Ba a sami aikace-aikacen lamuni da ke jiran amincewa ba.",
+    "noPendingTitle": "Babu neman aro da ke jiran kammalawa",
+    "noPendingBody": "Ba ka da neman aro da ke jiran dubawa.",
+    "noPendingButton": "Koma dashboard"
   },
   "loanApprovalModal": {
     "title": "An Amince da Lamuni Kuma An Tura Shi!",


### PR DESCRIPTION
## Summary

- Adds an explicit empty state for the loan repayment overview when no pending loan exists.
- Separates the loading state from the “no pending loan” state.
- Sends users back to the dashboard so the normal BVN/phone/loan-flow checks are not bypassed.

## Testing

- Visited `/take-a-loan/loan-repayment-overview` with no pending loan.
- Confirmed the empty state is displayed instead of a blank/white spinner state.
- Confirmed the button navigates back to the dashboard.
- Confirmed `npm run build` completes successfully.