### PR TITLE
Skip password reset OTP pre-verification

### DIFF
--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -7,9 +7,6 @@ export const signIn = (data) => axios.post("/auth/sign_in", data);
 export const requestPasswordReset = (data) =>
   axios.post("/auth/request_reset", data);
 
-export const verifyResetCode = (code) =>
-  axios.get(`/auth/verify/${code}`);
-
 export const resetPassword = (data) =>
   axios.patch("/auth/reset_password", data);
 

--- a/src/components/auth/VerifyPhoneEmail.jsx
+++ b/src/components/auth/VerifyPhoneEmail.jsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import * as yup from "yup";
-import { requestPasswordReset, verifyResetCode } from "../../api/authApi";
+import { requestPasswordReset } from "../../api/authApi";
 import arrowTimer from "../../assets/arrow-timer.svg";
 import BackgroundImage from "../BackgroundImage";
 import LoadingSpinner from "../LoadingSpinner";
@@ -115,23 +115,14 @@ function VerifyPhoneEmail() {
       otpCode.sixthDigit;
 
     try {
-      const response = await verifyResetCode(code);
+      localStorage.setItem("otpCode", code);
+      setShowVerificationSuccess(t("verify.success"));
 
-      if (response.status === 200) {
-        localStorage.setItem("otpCode", code);
-
-        setShowVerificationSuccess(response.data?.message);
-
-        setTimeout(() => {
-          navigate("/change-password");
-        }, 4000);
-      } else {
-        setShowFormError(response.data?.message);
-      }
-    } catch (error) {
-      console.error("Code verification error:", error);
-      setShowFormError(error.response?.data?.message);
-      // setLoading(false);
+      setTimeout(() => {
+        navigate("/change-password");
+      }, 2000);
+    } catch {
+      setShowFormError(t("verify.error"));
     } finally {
       setLoading(false);
       setTimeout(() => {

--- a/src/components/settings/SettingsVerifyEmailPhone.jsx
+++ b/src/components/settings/SettingsVerifyEmailPhone.jsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import * as yup from "yup";
-import { requestPasswordReset, verifyResetCode } from "../../api/authApi";
+import { requestPasswordReset } from "../../api/authApi";
 import arrowTimer from "../../assets/arrow-timer.svg";
 import LoadingSpinner from "../LoadingSpinner";
 
@@ -119,20 +119,15 @@ export default function SettingsVerifyEmailPhone() {
       otpCode.sixthDigit;
 
     try {
-      const response = await verifyResetCode(code);
       localStorage.setItem("otpCode", code);
+      setShowVerificationSuccess(t("settingsVerify.success"));
+      reset();
 
-      if (response.status === 200) {
-        setShowVerificationSuccess(response.data?.message);
-        reset();
-        setTimeout(() => {
-          navigate("/settings/reset-password");
-        }, 3000);
-      } else {
-        setShowFormError(response.data?.message);
-      }
-    } catch (error) {
-      setShowFormError(error.response?.data?.message);
+      setTimeout(() => {
+        navigate("/settings/reset-password");
+      }, 2000);
+    } catch {
+      setShowFormError(t("settingsVerify.error"));
     } finally {
       setLoading(false);
       setTimeout(() => {
@@ -156,6 +151,8 @@ export default function SettingsVerifyEmailPhone() {
         setValue("secondDigit", "");
         setValue("thirdDigit", "");
         setValue("fourthDigit", "");
+        setValue("fifthDigit", "");
+        setValue("sixthDigit", "");
         firstRef.current && firstRef.current.focus();
       } else {
         setShowResendFailure(response.data?.message);


### PR DESCRIPTION
## Summary

- Removes `/auth/verify/:code` pre-verification from both public and settings forgot-password OTP flows.
- Stores the entered OTP locally and moves users to the reset-password screen.
- Leaves final OTP validation to `/auth/reset_password` using identifier, code, and new password.
- Removes the unused verify reset code API helper.

## Testing

- Requested a password reset code from the public forgot-password flow.
- Entered a 6-digit code and confirmed the flow moves to change password.
- Requested a password reset code from Settings.
- Entered a 6-digit code and confirmed the flow moves to reset password.
- Confirmed reset password submits identifier, code, and new password.
- Confirmed `npm run build` completes successfully.