### PR TITLE
Fix/admin mobile pagination

### DIFF
--- a/src/components/admin/dashboard/UserManagementTable.jsx
+++ b/src/components/admin/dashboard/UserManagementTable.jsx
@@ -1,6 +1,6 @@
-import UserAvatar from "../../common/UserAvatar";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { getUsers } from "../../../api/adminApi";
+import UserAvatar from "../../common/UserAvatar";
 
 function UserManagementTable({
   onUserClick,
@@ -25,7 +25,7 @@ function UserManagementTable({
   const fetchUsers = async (
     page = 1,
     search = "",
-    startDate = ""
+    startDate = "",
     // endDate = ""
   ) => {
     try {
@@ -180,12 +180,6 @@ function UserManagementTable({
       {/* Pagination */}
       <div className="mt-6 flex items-center justify-between p-4">
         <div className="flex items-center space-x-4">
-          <span className="text-sm text-gray-700">
-            Showing {(pagination.currentPage - 1) * perPage + 1} to{" "}
-            {Math.min(pagination.currentPage * perPage, pagination.totalUsers)}{" "}
-            of {pagination.totalUsers} results
-          </span>
-
           <div className="flex items-center space-x-2">
             <label className="text-sm text-gray-700">Per page:</label>
             <select
@@ -195,7 +189,7 @@ function UserManagementTable({
             >
               <option value={5}>5</option>
               <option value={10}>10</option>
-              <option value={20}>20</option>
+              <option value={25}>25</option>
               <option value={50}>50</option>
             </select>
           </div>
@@ -209,10 +203,6 @@ function UserManagementTable({
           >
             Previous
           </button>
-
-          <span className="px-3 py-1 text-sm text-gray-700">
-            Page {pagination.currentPage} of {pagination.totalPages}
-          </span>
 
           <button
             onClick={() => handlePageChange(pagination.currentPage + 1)}

--- a/src/components/admin/kyc/BVNVerification.jsx
+++ b/src/components/admin/kyc/BVNVerification.jsx
@@ -1,19 +1,16 @@
-
-
-
 import { useEffect, useState } from "react";
-import UserDetailsModal from "../modals/UserDetailsModal";
-import UserAvatar from "../../common/UserAvatar";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
 import {
   getVerifications,
   processIdentityVerification,
 } from "../../../api/adminApi";
-import unverifiedIcon from "../../../assets/unverified icon.svg";
-import verifiedIcon from "../../../assets/verified icon.svg";
 import calendarIcon from "../../../assets/calendar icon.svg";
 import chevronDown from "../../../assets/chevron-down.svg";
-import DatePicker from "react-datepicker";
-import "react-datepicker/dist/react-datepicker.css";
+import unverifiedIcon from "../../../assets/unverified icon.svg";
+import verifiedIcon from "../../../assets/verified icon.svg";
+import UserAvatar from "../../common/UserAvatar";
+import UserDetailsModal from "../modals/UserDetailsModal";
 
 function formatDateText(date) {
   if (!date) return "";
@@ -41,7 +38,7 @@ function BVNVerification() {
   const [totalPages, setTotalPages] = useState(1);
   const [totalVerifications, setTotalVerifications] = useState(0);
   const [showPerPageDropdown, setShowPerPageDropdown] = useState(false);
-  const perPageOptions = [10, 20, 30, 40, 50];
+  const perPageOptions = [5, 10, 25, 50];
 
   // debounce search
   useEffect(() => {
@@ -93,9 +90,7 @@ function BVNVerification() {
     try {
       await processIdentityVerification(userId, "VERIFY", "BVN");
       setBvnData((prev) =>
-        prev.map((u) =>
-          u._id === userId ? { ...u, status: "verified" } : u
-        )
+        prev.map((u) => (u._id === userId ? { ...u, status: "verified" } : u)),
       );
     } catch (err) {
       alert("Failed to verify user");
@@ -109,9 +104,7 @@ function BVNVerification() {
     try {
       await processIdentityVerification(userId, "REJECT", "BVN");
       setBvnData((prev) =>
-        prev.map((u) =>
-          u._id === userId ? { ...u, status: "rejected" } : u
-        )
+        prev.map((u) => (u._id === userId ? { ...u, status: "rejected" } : u)),
       );
     } catch (err) {
       alert("Failed to reject user");
@@ -130,14 +123,9 @@ function BVNVerification() {
     setShowPerPageDropdown(false);
   };
 
-  // showing X–Y
-  const startCount = (currentPage - 1) * itemsPerPage + 1;
-  const endCount = Math.min(currentPage * itemsPerPage, totalVerifications);
-
   if (loading)
     return <div className="p-6 text-center">Loading BVN verifications...</div>;
-  if (error)
-    return <div className="p-6 text-center text-red-500">{error}</div>;
+  if (error) return <div className="p-6 text-center text-red-500">{error}</div>;
 
   return (
     <div className="space-y-6">
@@ -183,8 +171,12 @@ function BVNVerification() {
             stroke="currentColor"
             viewBox="0 0 24 24"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
           </svg>
         </div>
       </div>
@@ -227,8 +219,12 @@ function BVNVerification() {
               stroke="currentColor"
               viewBox="0 0 24 24"
             >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
             </svg>
           </div>
         </div>
@@ -240,19 +236,36 @@ function BVNVerification() {
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Phone</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">BVN</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Name
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Phone
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  BVN
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Status
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Date
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Action
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Action
+                </th>
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
               {bvnData.length === 0 ? (
                 <tr>
-                  <td colSpan={7} className="px-6 py-4 text-center text-gray-500">
+                  <td
+                    colSpan={7}
+                    className="px-6 py-4 text-center text-gray-500"
+                  >
                     No BVN verifications found.
                   </td>
                 </tr>
@@ -272,8 +285,12 @@ function BVNVerification() {
                         </div>
                       </div>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{user.phone}</td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{user.bvn || user.identity_value}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {user.phone}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      {user.bvn || user.identity_value}
+                    </td>
                     <td className="px-6 py-4">
                       {user.bvn_verified === true ? (
                         <div className="inline-flex gap-1 items-center py-[2px] px-1.5 rounded-[6px] text-[#16A34A] text-xs border border-[#D3F3DF] bg-[#F2FDF5] w-max min-w-0">
@@ -301,7 +318,9 @@ function BVNVerification() {
                           className="text-yellow-600 hover:text-yellow-900"
                           disabled={actionLoading === user._id}
                         >
-                          {actionLoading === user._id ? "Verifying..." : "Verify"}
+                          {actionLoading === user._id
+                            ? "Verifying..."
+                            : "Verify"}
                         </button>
                       ) : (
                         <button
@@ -339,10 +358,6 @@ function BVNVerification() {
           >
             Previous
           </button>
-
-          <span className="text-sm text-gray-600">
-            Showing {startCount}-{endCount} of {totalVerifications}
-          </span>
 
           <div className="relative">
             <div

--- a/src/components/admin/kyc/NINVerification.jsx
+++ b/src/components/admin/kyc/NINVerification.jsx
@@ -1,18 +1,16 @@
-
-
 import { useEffect, useState } from "react";
-import UserDetailsModal from "../modals/UserDetailsModal";
-import UserAvatar from "../../common/UserAvatar";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
 import {
   getVerifications,
   processIdentityVerification,
 } from "../../../api/adminApi";
-import unverifiedIcon from "../../../assets/unverified icon.svg";
-import verifiedIcon from "../../../assets/verified icon.svg";
 import calendarIcon from "../../../assets/calendar icon.svg";
 import chevronDown from "../../../assets/chevron-down.svg";
-import DatePicker from "react-datepicker";
-import "react-datepicker/dist/react-datepicker.css";
+import unverifiedIcon from "../../../assets/unverified icon.svg";
+import verifiedIcon from "../../../assets/verified icon.svg";
+import UserAvatar from "../../common/UserAvatar";
+import UserDetailsModal from "../modals/UserDetailsModal";
 
 function formatDateText(date) {
   if (!date) return "";
@@ -42,7 +40,7 @@ function NINVerification() {
   const [totalPages, setTotalPages] = useState(1);
   const [totalVerifications, setTotalVerifications] = useState(0);
   const [showPerPageDropdown, setShowPerPageDropdown] = useState(false);
-  const perPageOptions = [10, 20, 30, 40, 50];
+  const perPageOptions = [5, 10, 25, 50];
 
   // debounce
   useEffect(() => {
@@ -64,7 +62,7 @@ function NINVerification() {
         if (startDate) {
           const d = startDate;
           params.start_date = `${d.getFullYear()}-${String(
-            d.getMonth() + 1
+            d.getMonth() + 1,
           ).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
         }
         const res = await getVerifications(params);
@@ -95,7 +93,7 @@ function NINVerification() {
     try {
       await processIdentityVerification(userId, "VERIFY", "NIN");
       setNinData((prev) =>
-        prev.map((u) => (u._id === userId ? { ...u, status: "verified" } : u))
+        prev.map((u) => (u._id === userId ? { ...u, status: "verified" } : u)),
       );
     } catch (err) {
       alert("Failed to verify user");
@@ -109,7 +107,7 @@ function NINVerification() {
     try {
       await processIdentityVerification(userId, "REJECT", "NIN");
       setNinData((prev) =>
-        prev.map((u) => (u._id === userId ? { ...u, status: "rejected" } : u))
+        prev.map((u) => (u._id === userId ? { ...u, status: "rejected" } : u)),
       );
     } catch (err) {
       alert("Failed to reject user");
@@ -127,10 +125,6 @@ function NINVerification() {
     setCurrentPage(1);
     setShowPerPageDropdown(false);
   };
-
-  // showing X–Y
-  const startCount = (currentPage - 1) * itemsPerPage + 1;
-  const endCount = Math.min(currentPage * itemsPerPage, totalVerifications);
 
   if (loading)
     return <div className="p-6 text-center">Loading NIN verifications...</div>;
@@ -368,10 +362,6 @@ function NINVerification() {
           >
             Previous
           </button>
-
-          <span className="text-sm text-gray-600">
-            Showing {startCount}-{endCount} of {totalVerifications}
-          </span>
 
           <div className="relative">
             <div

--- a/src/components/admin/loans/LoanApplications.jsx
+++ b/src/components/admin/loans/LoanApplications.jsx
@@ -397,7 +397,7 @@ function LoanApplications() {
             {/* Previous button - left */}
             <div>
               <button
-                className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+                className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled={pagination.currentPage === 1}
                 onClick={() => handlePageChange(pagination.currentPage - 1)}
               >

--- a/src/components/admin/loans/LoanApplications.jsx
+++ b/src/components/admin/loans/LoanApplications.jsx
@@ -1,13 +1,12 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "react-toastify";
-import UserDetailsModal from "../modals/UserDetailsModal";
-import LoanApplicationModal from "../modals/LoanApplicationModal";
-import UserAvatar from "../../common/UserAvatar";
 import {
   getLoanApplications,
-  updateLoanApplicationStatus,
   getUserDetails,
+  updateLoanApplicationStatus,
 } from "../../../api/adminApi";
+import UserAvatar from "../../common/UserAvatar";
+import UserDetailsModal from "../modals/UserDetailsModal";
 
 function LoanApplications() {
   const [loanApplications, setLoanApplications] = useState([]);
@@ -42,7 +41,7 @@ function LoanApplications() {
     page = 1,
     search = "",
     startDate = "",
-    endDate = ""
+    endDate = "",
   ) => {
     try {
       setLoading(true);
@@ -78,8 +77,8 @@ function LoanApplications() {
             app.status === "PENDING"
               ? "PENDING"
               : app.status === "APPROVED"
-              ? "APPROVED"
-              : "REJECTED",
+                ? "APPROVED"
+                : "REJECTED",
           status: app.status,
           avatar: app.user?.avatar || null,
           tier: app.user?.credit_score?.tier || "N/A",
@@ -327,7 +326,7 @@ function LoanApplications() {
               {loanApplications.map((loan) => (
                 <tr
                   key={loan.id}
-                //   onClick={() => handleLoanClick(loan)}
+                  //   onClick={() => handleLoanClick(loan)}
                   className="hover:bg-gray-50 cursor-pointer"
                 >
                   <td className="px-6 py-4 whitespace-nowrap">
@@ -370,10 +369,25 @@ function LoanApplications() {
         <div className="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6">
           {/* Mobile pagination */}
           <div className="flex-1 flex justify-between sm:hidden">
-            <button className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+            <button
+              type="button"
+              disabled={pagination.currentPage === 1}
+              onClick={() => handlePageChange(pagination.currentPage - 1)}
+              className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
               Previous
             </button>
-            <button className="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50">
+
+            <span className="self-center text-sm text-gray-600">
+              Page {pagination.currentPage} of {pagination.totalPages}
+            </span>
+
+            <button
+              type="button"
+              disabled={pagination.currentPage === pagination.totalPages}
+              onClick={() => handlePageChange(pagination.currentPage + 1)}
+              className="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
               Next
             </button>
           </div>

--- a/src/components/admin/loans/LoanApplications.jsx
+++ b/src/components/admin/loans/LoanApplications.jsx
@@ -378,9 +378,19 @@ function LoanApplications() {
               Previous
             </button>
 
-            <span className="self-center text-sm text-gray-600">
-              Page {pagination.currentPage} of {pagination.totalPages}
-            </span>
+            <div className="flex items-center">
+              <label className="text-sm text-gray-700 mr-2">Per page</label>
+              <select
+                value={perPage}
+                onChange={(e) => handlePerPageChange(parseInt(e.target.value))}
+                className="border border-gray-300 rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-yellow-500 focus:border-yellow-500"
+              >
+                <option value="5">5</option>
+                <option value="10">10</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+              </select>
+            </div>
 
             <button
               type="button"
@@ -423,7 +433,7 @@ function LoanApplications() {
             {/* Next button - right */}
             <div>
               <button
-                className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+                className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled={pagination.currentPage === pagination.totalPages}
                 onClick={() => handlePageChange(pagination.currentPage + 1)}
               >

--- a/src/components/admin/repayments/LoanRepaymentManagement.jsx
+++ b/src/components/admin/repayments/LoanRepaymentManagement.jsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { getRepayments } from "../../../api/repaymentsApi";
+import UserAvatar from "../../common/UserAvatar";
 import RepaymentDetailsModal from "../modals/RepaymentDetailsModal";
 import UserDetailsModal from "../modals/UserDetailsModal";
-import UserAvatar from "../../common/UserAvatar";
-import { getRepayments } from "../../../api/repaymentsApi";
 
 function LoanRepaymentManagement() {
   const [repaymentData, setRepaymentData] = useState([]);
@@ -43,7 +43,7 @@ function LoanRepaymentManagement() {
     page = 1,
     search = "",
     date = "",
-    limit = 10
+    limit = 10,
   ) => {
     try {
       setLoading(true);
@@ -150,9 +150,9 @@ function LoanRepaymentManagement() {
     handlePageChange(pagination.currentPage + 1);
   };
 
-  const handlePerPageChange = (e) => {
-    setPerPage(Number(e.target.value));
-    setPagination((prev) => ({ ...prev, currentPage: 1 })); // Reset to page 1
+  const handlePerPageChange = (newPerPage) => {
+    setPerPage(Number(newPerPage));
+    setPagination((prev) => ({ ...prev, currentPage: 1 }));
   };
 
   const dataToDisplay = repaymentData;
@@ -322,50 +322,22 @@ function LoanRepaymentManagement() {
           </table>
         </div>
 
-        <div className="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6">
-          <div className="flex-1 flex justify-between sm:hidden">
+        <div className="bg-white px-4 py-3 border-t border-gray-200 sm:px-6">
+          <div className="flex items-center justify-between sm:hidden">
             <button
+              type="button"
               onClick={handlePrevPage}
               disabled={pagination.currentPage === 1}
               className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Previous
             </button>
-            <button
-              onClick={handleNextPage}
-              disabled={pagination.currentPage === pagination.totalPages}
-              className="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Next
-            </button>
-          </div>
-          <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
-            <div>
-              <p className="text-sm text-gray-700">
-                Showing{" "}
-                <span className="font-medium">
-                  {(pagination.currentPage - 1) * perPage + 1}
-                </span>{" "}
-                to{" "}
-                <span className="font-medium">
-                  {Math.min(
-                    pagination.currentPage * perPage,
-                    pagination.totalRepayments
-                  )}
-                </span>{" "}
-                of{" "}
-                <span className="font-medium">
-                  {pagination.totalRepayments}
-                </span>{" "}
-                results
-              </p>
-            </div>
 
             <div className="flex items-center">
               <label className="text-sm text-gray-700 mr-2">Per page</label>
               <select
                 value={perPage}
-                onChange={handlePerPageChange}
+                onChange={(e) => handlePerPageChange(e.target.value)}
                 className="border border-gray-300 rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-yellow-500 focus:border-yellow-500"
               >
                 <option value="5">5</option>
@@ -374,24 +346,49 @@ function LoanRepaymentManagement() {
                 <option value="50">50</option>
               </select>
             </div>
-            <div>
-              <nav className="relative z-0 inline-flex rounded-md shadow-sm -space-x-px">
-                <button
-                  onClick={handlePrevPage}
-                  disabled={pagination.currentPage === 1}
-                  className="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Previous
-                </button>
-                <button
-                  onClick={handleNextPage}
-                  disabled={pagination.currentPage === pagination.totalPages}
-                  className="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Next
-                </button>
-              </nav>
+
+            <button
+              type="button"
+              onClick={handleNextPage}
+              disabled={pagination.currentPage === pagination.totalPages}
+              className="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Next
+            </button>
+          </div>
+
+          <div className="hidden sm:flex sm:items-center sm:justify-between">
+            <button
+              type="button"
+              onClick={handlePrevPage}
+              disabled={pagination.currentPage === 1}
+              className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Previous
+            </button>
+
+            <div className="flex items-center">
+              <label className="text-sm text-gray-700 mr-2">Per page</label>
+              <select
+                value={perPage}
+                onChange={(e) => handlePerPageChange(e.target.value)}
+                className="border border-gray-300 rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-yellow-500 focus:border-yellow-500"
+              >
+                <option value="5">5</option>
+                <option value="10">10</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+              </select>
             </div>
+
+            <button
+              type="button"
+              onClick={handleNextPage}
+              disabled={pagination.currentPage === pagination.totalPages}
+              className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Next
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/admin/user-management/UserManagementTable.jsx
+++ b/src/components/admin/user-management/UserManagementTable.jsx
@@ -1,11 +1,14 @@
-
-
 import { useEffect, useState } from "react";
-import UserAvatar from "../../common/UserAvatar";
 import { getUsers } from "../../../api/adminApi";
 import NairaIcon from "../../../assets/naira icon.svg";
+import UserAvatar from "../../common/UserAvatar";
 
-function UserManagementTable({ onUserClick, searchTerm = "", selectedDate = "", filters }) {
+function UserManagementTable({
+  onUserClick,
+  searchTerm = "",
+  selectedDate = "",
+  filters,
+}) {
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -37,17 +40,25 @@ function UserManagementTable({ onUserClick, searchTerm = "", selectedDate = "", 
       if (searchTerm) params.search = searchTerm;
       if (selectedDate) params.start_date = selectedDate;
 
-      
-      if (filters.tier) params.tier = parseInt(filters.tier.split(' ')[1], 10);
-      if (filters.kycStatus.includes("BVN Verified")) params.bvn_verified = true;
-      if (filters.kycStatus.includes("BVN Unverified")) params.bvn_verified = false;
-      if (filters.kycStatus.includes("NIN Verified")) params.nin_verified = true;
-      if (filters.kycStatus.includes("NIN Unverified")) params.nin_verified = false;
+      if (filters.tier) params.tier = parseInt(filters.tier.split(" ")[1], 10);
+      if (filters.kycStatus.includes("BVN Verified"))
+        params.bvn_verified = true;
+      if (filters.kycStatus.includes("BVN Unverified"))
+        params.bvn_verified = false;
+      if (filters.kycStatus.includes("NIN Verified"))
+        params.nin_verified = true;
+      if (filters.kycStatus.includes("NIN Unverified"))
+        params.nin_verified = false;
 
       const res = await getUsers(params);
 
       if (res.data) {
-        const { users: userData, total_users, total_pages, current_page } = res.data;
+        const {
+          users: userData,
+          total_users,
+          total_pages,
+          current_page,
+        } = res.data;
         const transformedUsers = (userData || []).map((user) => ({
           _id: user._id,
           full_name: user.full_name || "Unknown User",
@@ -59,7 +70,7 @@ function UserManagementTable({ onUserClick, searchTerm = "", selectedDate = "", 
           loan_due_date: user.loan_due_date,
           profile_picture: user.profile_picture || null,
         }));
-        
+
         setUsers(transformedUsers);
         setPagination({
           currentPage: current_page,
@@ -187,17 +198,20 @@ function UserManagementTable({ onUserClick, searchTerm = "", selectedDate = "", 
           )}
         </tbody>
       </table>
-      
+
       {/* Pagination */}
       {users.length > 0 && (
-        <div className="mt-6 flex items-center justify-between p-4">
-          <div className="flex items-center space-x-4">
+        <div className="mt-6 flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:space-x-4">
             <span className="text-sm text-gray-700">
               Showing {(pagination.currentPage - 1) * perPage + 1} to{" "}
-              {Math.min(pagination.currentPage * perPage, pagination.totalUsers)}{" "}
+              {Math.min(
+                pagination.currentPage * perPage,
+                pagination.totalUsers,
+              )}{" "}
               of {pagination.totalUsers} results
             </span>
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center justify-between gap-2 sm:justify-start">
               <label className="text-sm text-gray-700">Per page:</label>
               <select
                 value={perPage}

--- a/src/components/admin/user-management/UserManagementTable.jsx
+++ b/src/components/admin/user-management/UserManagementTable.jsx
@@ -96,9 +96,8 @@ function UserManagementTable({
     }
   };
 
-  const handlePerPageChange = (e) => {
-    const newPerPage = parseInt(e.target.value);
-    setPerPage(newPerPage);
+  const handlePerPageChange = (newPerPage) => {
+    setPerPage(Number(newPerPage));
   };
 
   if (loading) return <div className="p-6 text-center">Loading users...</div>;
@@ -201,48 +200,77 @@ function UserManagementTable({
 
       {/* Pagination */}
       {users.length > 0 && (
-        <div className="mt-6 flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:space-x-4">
-            <span className="text-sm text-gray-700">
-              Showing {(pagination.currentPage - 1) * perPage + 1} to{" "}
-              {Math.min(
-                pagination.currentPage * perPage,
-                pagination.totalUsers,
-              )}{" "}
-              of {pagination.totalUsers} results
-            </span>
-            <div className="flex items-center justify-between gap-2 sm:justify-start">
-              <label className="text-sm text-gray-700">Per page:</label>
-              <select
-                value={perPage}
-                onChange={handlePerPageChange}
-                className="px-2 py-1 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                <option value={5}>5</option>
-                <option value={10}>10</option>
-                <option value={20}>20</option>
-                <option value={50}>50</option>
-              </select>
-            </div>
-          </div>
-          <div className="flex items-center space-x-2">
+        <div className="mt-6 border-t border-gray-200 bg-white px-4 py-3 sm:px-6">
+          <div className="flex items-center justify-between sm:hidden">
             <button
+              type="button"
               onClick={() => handlePageChange(pagination.currentPage - 1)}
               disabled={pagination.currentPage <= 1}
-              className="px-3 py-1 text-sm border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Previous
             </button>
-            <span className="px-3 py-1 text-sm text-gray-700">
-              Page {pagination.currentPage} of {pagination.totalPages}
-            </span>
+
+            <div className="flex items-center">
+              <label className="text-sm text-gray-700 mr-2">Per page</label>
+              <select
+                value={perPage}
+                onChange={(e) => handlePerPageChange(e.target.value)}
+                className="border border-gray-300 rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-yellow-500 focus:border-yellow-500"
+              >
+                <option value="5">5</option>
+                <option value="10">10</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+              </select>
+            </div>
+
             <button
+              type="button"
               onClick={() => handlePageChange(pagination.currentPage + 1)}
               disabled={pagination.currentPage >= pagination.totalPages}
-              className="px-3 py-1 text-sm border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Next
             </button>
+          </div>
+
+          <div className="hidden sm:flex sm:items-center sm:justify-between">
+            <div>
+              <button
+                type="button"
+                onClick={() => handlePageChange(pagination.currentPage - 1)}
+                disabled={pagination.currentPage <= 1}
+                className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Previous
+              </button>
+            </div>
+
+            <div className="flex items-center">
+              <label className="text-sm text-gray-700 mr-2">Per page</label>
+              <select
+                value={perPage}
+                onChange={(e) => handlePerPageChange(e.target.value)}
+                className="border border-gray-300 rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-yellow-500 focus:border-yellow-500"
+              >
+                <option value={5}>5</option>
+                <option value={10}>10</option>
+                <option value={25}>25</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
+
+            <div>
+              <button
+                type="button"
+                onClick={() => handlePageChange(pagination.currentPage + 1)}
+                disabled={pagination.currentPage >= pagination.totalPages}
+                className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Next
+              </button>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- Standardizes admin pagination footers to use Previous, Per page, and Next controls.
- Removes inconsistent "Showing results" and page-count text from admin table footers.
- Wires mobile pagination controls and per-page selectors.
- Fixes mobile per-page selection for User Management and Loan Repayment.
- Aligns per-page options across admin tables to 5, 10, 25, and 50.
- Adds consistent disabled styling for Previous and Next buttons.

## Testing

- Confirmed Previous and Next work on mobile and desktop.
- Confirmed Per page selection refetches data on mobile and desktop.
- Confirmed pagination resets to page 1 after changing Per page where applicable.
- Confirmed disabled states display correctly on first and last pages.
- Confirmed `npm run build` passes.