### PR TITLE
Handle stale lazy-loaded route chunks

### DIFF
--- a/src/components/LazyLoadErrorBoundary.jsx
+++ b/src/components/LazyLoadErrorBoundary.jsx
@@ -1,0 +1,77 @@
+import { Component } from "react";
+import { useTranslation } from "react-i18next";
+
+const CHUNK_RELOAD_KEY = "wapfi:chunk-reload-at";
+const RELOAD_WINDOW_MS = 30000;
+
+function isChunkLoadError(error) {
+  const message = error?.message || "";
+
+  return (
+    message.includes("Failed to fetch dynamically imported module") ||
+    message.includes("Importing a module script failed") ||
+    message.includes("Loading chunk")
+  );
+}
+
+function LazyLoadFallback() {
+  const { t } = useTranslation();
+
+  const handleRefresh = () => {
+    sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+    window.location.reload();
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4 text-center">
+      <div>
+        <h1 className="text-xl font-semibold text-gray-900">
+          {t("app_error.title")}
+        </h1>
+        <p className="mt-2 text-sm text-gray-600">
+          {t("app_error.message")}
+        </p>
+        <button
+          type="button"
+          onClick={handleRefresh}
+          className="mt-4 rounded-md bg-[#B88E00] px-4 py-2 text-sm font-medium text-white"
+        >
+          {t("app_error.refresh")}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+class LazyLoadErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error) {
+    if (!isChunkLoadError(error)) return;
+
+    const lastReloadAt = Number(sessionStorage.getItem(CHUNK_RELOAD_KEY) || 0);
+    const canReload = Date.now() - lastReloadAt > RELOAD_WINDOW_MS;
+
+    if (canReload) {
+      sessionStorage.setItem(CHUNK_RELOAD_KEY, String(Date.now()));
+      window.location.reload();
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <LazyLoadFallback />;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default LazyLoadErrorBoundary;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -767,5 +767,10 @@
     "previous": "Previous",
     "next": "Next",
     "perPage": "Per page"
+  },
+  "app_error": {
+    "title": "Something went wrong",
+    "message": "The app needs to refresh to load the latest version.",
+    "refresh": "Refresh"
   }
 }

--- a/src/locales/ha.json
+++ b/src/locales/ha.json
@@ -766,5 +766,10 @@
     "previous": "Baya",
     "next": "Gaba",
     "perPage": "A shafi daya"
+  },
+  "app_error": {
+    "title": "Wani abu ya faru",
+    "message": "Aikace-aikacen na bukatar sabuntawa domin loda sabon sigar.",
+    "refresh": "Sabunta"
   }
 }

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -4,7 +4,9 @@ import PageLoader from "../components/PageLoader";
 
 // Structural components — always needed immediately, not lazy-loaded
 import AdminLayout from "../components/admin/layout/AdminLayout";
+import SignOut from "../components/auth/SignOut";
 import Layout from "../components/dashboard/layout/Layout";
+import LazyLoadErrorBoundary from "../components/LazyLoadErrorBoundary";
 import { DisbursedLoansProvider } from "../context/DisbursedLoansContext";
 import { LoanFormProvider } from "../context/LoanFormContext";
 import { NotificationProvider } from "../context/NotificationContext";
@@ -19,7 +21,7 @@ const SignUpAccountVerification = lazy(
   () => import("../components/auth/SignUpAccountVerification"),
 );
 const SignIn = lazy(() => import("../components/auth/SignIn"));
-const SignOut = lazy(() => import("../components/auth/SignOut"));
+// const SignOut = lazy(() => import("../components/auth/SignOut"));
 const ForgotPassword = lazy(() => import("../components/auth/ForgotPassword"));
 const VerifyPhoneEmail = lazy(
   () => import("../components/auth/VerifyPhoneEmail"),
@@ -123,9 +125,15 @@ const Notifications = lazy(
 );
 const Support = lazy(() => import("../components/settings/Support"));
 
-// Tiny helper to avoid repeating Suspense on every route element
+// // Tiny helper to avoid repeating Suspense on every route element
+// const S = ({ children }) => (
+//   <Suspense fallback={<PageLoader />}>{children}</Suspense>
+// );
+
 const S = ({ children }) => (
-  <Suspense fallback={<PageLoader />}>{children}</Suspense>
+  <LazyLoadErrorBoundary>
+    <Suspense fallback={<PageLoader />}>{children}</Suspense>
+  </LazyLoadErrorBoundary>
 );
 
 const PageTitle = ({ title, children }) => {


### PR DESCRIPTION
## Summary
- Loads SignOut eagerly so logout is not blocked by a stale dynamic chunk
- Adds a lazy-load error boundary to recover from stale route chunks after deployment
- Adds translated fallback text for English and Hausa
