### PR TITLE
Switch auth to http-only cookies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ localhost-key.pem
 
 test.py
 combined_code.txt
+.env.local

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -7,40 +7,43 @@ if (!apiBaseUrl) {
   throw new Error("VITE_API_BASE_URL is not configured");
 }
 
-let isHandlingUnauthorized = false;
-
 const instance = axios.create({
   baseURL: apiBaseUrl,
-
+  withCredentials: true,
   headers: {
     "Content-Type": "application/json",
     Accept: "application/json",
   },
 });
 
-instance.interceptors.request.use((config) => {
-  const token = localStorage.getItem("auth_token");
-
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-
-  return config;
-});
-
 instance.interceptors.response.use(
   (response) => response,
-  (error) => {
-    const status = error.response?.status;
-    const hasToken = Boolean(localStorage.getItem("auth_token"));
+  async (error) => {
+    const originalRequest = error.config;
 
-    if (status === 401 && hasToken && !isHandlingUnauthorized) {
-      isHandlingUnauthorized = true;
+    if (
+      error.response?.status === 401 &&
+      originalRequest &&
+      !originalRequest._retried &&
+      !originalRequest.url?.includes("/auth/refresh") &&
+      !originalRequest.url?.includes("/auth/sign_in") &&
+      !originalRequest.url?.includes("/auth/sign_out")
+    ) {
+      originalRequest._retried = true;
 
-      clearSessionData();
-      sessionStorage.setItem("sessionExpired", "true");
+      try {
+        await instance.post("/auth/refresh");
+        return instance(originalRequest);
+      } catch {
+        clearSessionData();
 
-      window.location.replace("/sign-in");
+        if (window.location.pathname !== "/sign-in") {
+          sessionStorage.setItem("sessionExpired", "true");
+          window.location.replace("/sign-in");
+        }
+
+        return Promise.reject(error);
+      }
     }
 
     return Promise.reject(error);

--- a/src/components/auth/SignIn.jsx
+++ b/src/components/auth/SignIn.jsx
@@ -127,7 +127,6 @@ function SignIn() {
       });
 
       if (response.status === 200) {
-        localStorage.setItem("auth_token", response.data.token);
         // setShowFormError("");
         setShowSuccessMessage(response.data?.message);
         reset();

--- a/src/context/UserContext.jsx
+++ b/src/context/UserContext.jsx
@@ -35,10 +35,24 @@ export function UserContextProvider({ children }) {
     }
   }, []);
 
-  // Initial fetch on mount
+  // Initial fetch on mount, but only on pages that need an authenticated user.
   useEffect(() => {
+    const publicPaths = [
+      "/",
+      "/select-language",
+      "/sign-in",
+      "/sign-up",
+      "/forgot-password",
+      "/verify-code",
+      "/change-password",
+    ];
+
+    if (publicPaths.includes(window.location.pathname)) {
+      return;
+    }
+
     refreshUserData();
-  }, [refreshUserData]); // Now it depends on the memoized function
+  }, [refreshUserData]);
 
   return (
     <UserContext.Provider value={{ userData, setUserData, refreshUserData }}>

--- a/src/utils/clearSessionData.js
+++ b/src/utils/clearSessionData.js
@@ -1,5 +1,4 @@
 const sessionStorageKeys = [
-  "auth_token",
   "dashboardData",
   "loanConfirmationData",
   "repaymentsData",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,19 +1,39 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      "/api": {
+        target:
+          "https://wapfi-backend-service-staging-718658406507.europe-west1.run.app",
+        changeOrigin: true,
+        secure: true,
+      },
+    },
+  },
   build: {
     rollupOptions: {
       output: {
         manualChunks: {
-          "vendor-react": ["react", "react-dom", "react-router-dom", "react-is"],
+          "vendor-react": [
+            "react",
+            "react-dom",
+            "react-router-dom",
+            "react-is",
+          ],
           "vendor-charts": ["recharts"],
           "vendor-i18n": ["i18next", "react-i18next", "i18next-http-backend"],
           "vendor-forms": ["react-hook-form", "@hookform/resolvers", "yup"],
-          "vendor-misc": ["axios", "react-toastify", "react-datepicker", "date-fns"],
+          "vendor-misc": [
+            "axios",
+            "react-toastify",
+            "react-datepicker",
+            "date-fns",
+          ],
         },
       },
     },


### PR DESCRIPTION
## Summary
- Switches frontend auth from Bearer token storage to http-only cookie authentication
- Sends cookies on API requests using Axios `withCredentials`
- Adds refresh-on-401 retry handling for expired access cookies
- Stops storing `auth_token` in localStorage
- Prevents signed-out users on public pages from entering a refresh loop
- Adds a Vite dev proxy for local cookie-auth testing

## Testing
- Ran `npm run build`
- Verified login sets `access_token` and `refresh_token` cookies
- Verified `/users/me` sends the access cookie
- Verified `/auth/refresh` sends the refresh cookie
- Verified requests no longer send `Authorization: Bearer`