### PR TITLE
Use staging API domain for frontend config

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 # Copy this to .env.local for local development
 # Vite exposes only variables prefixed with VITE_ to the browser bundle
 
-VITE_API_BASE_URL=https://wapfi-backend-service-staging-718658406507.europe-west1.run.app/api/v1
+# VITE_API_BASE_URL=https://wapfi-backend-service-staging-718658406507.europe-west1.run.app/api/v1
+VITE_API_BASE_URL=https://api-staging.wapfilending.com/api/v1

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,8 +8,9 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target:
-          "https://wapfi-backend-service-staging-718658406507.europe-west1.run.app",
+        // target:
+        //   "https://wapfi-backend-service-staging-718658406507.europe-west1.run.app",
+        target: "https://api-staging.wapfilending.com",
         changeOrigin: true,
         secure: true,
       },


### PR DESCRIPTION
## Summary
- Updates frontend API config to use the staging API domain
- Aligns local Vite proxy target with the staging API domain
- Keeps local development using `/api/v1` through the Vite proxy

## Testing
- `npm run build` runs successfully