### PR TITLE
Include bank code in loan application payload

### DIFF
--- a/src/components/take a loan/LoanRepaymentOverview.jsx
+++ b/src/components/take a loan/LoanRepaymentOverview.jsx
@@ -79,6 +79,7 @@ export default function LoanRepaymentOverview() {
           account_name: loanDetails.bank_account?.account_name ?? "",
           account_number: loanDetails.disbursement_account ?? "",
           bank_name: loanDetails.bank_account?.bank_name ?? "",
+          bank_code: loanDetails.bank_account?.bank_code ?? "",
           repayment_method: loanDetails.repayment_method ?? "",
           recyclable_drop_off_known:
             loanDetails.recyclable_drop_off_known ?? false,

--- a/src/components/take a loan/Step2BankAccount.jsx
+++ b/src/components/take a loan/Step2BankAccount.jsx
@@ -53,6 +53,7 @@ export default function Step2BankAccount() {
     defaultValues: {
       account_number: loanFormData.account_number,
       bank_name: loanFormData.bank_name,
+      bank_code: loanFormData.bank_code,
     },
   });
 
@@ -69,11 +70,14 @@ export default function Step2BankAccount() {
     setLoading(true);
     setFormError(false);
 
+    const submittedBank = banks.find((bank) => bank.name === data.bank_name);
+
     try {
       updateLoanFormData({
         account_name: userData.full_name,
         account_number: data.account_number,
         bank_name: data.bank_name.trim(),
+        bank_code: submittedBank?.code || "",
       });
 
       if (setHasUnsavedChanges) {
@@ -172,6 +176,7 @@ export default function Step2BankAccount() {
                   key={bank.code}
                   onClick={() => {
                     setValue("bank_name", bank.name, { shouldValidate: true });
+                    setValue("bank_code", bank.code, { shouldValidate: true });
                     setDisplayBankDropdown(false);
                   }}
                   className="flex items-center gap-2 text-left text-[#222] hover:bg-[rgba(0,0,0,0.05)] p-2 rounded"

--- a/src/components/take a loan/Step4Summary.jsx
+++ b/src/components/take a loan/Step4Summary.jsx
@@ -1,11 +1,11 @@
-import editIcon from "../../assets/edit icon.svg";
-import LoadingSpinner from "../LoadingSpinner";
-import { useLoanForm } from "../../context/LoanFormContext";
-import { useNavigate } from "react-router-dom";
-import { useState, useEffect } from "react";
-import { applyForLoan, updatePendingLoanDetails } from "../../api/loansApi";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import { applyForLoan, updatePendingLoanDetails } from "../../api/loansApi";
+import editIcon from "../../assets/edit icon.svg";
 import { useDashboard } from "../../context/DashboardContext";
+import { useLoanForm } from "../../context/LoanFormContext";
+import LoadingSpinner from "../LoadingSpinner";
 
 export default function Step4Summary() {
   const { t } = useTranslation();
@@ -29,7 +29,8 @@ export default function Step4Summary() {
             updateLoanFormData({
               loan_amount: freshDashboardRes.pending_loan.loan_amount ?? "",
               loan_purpose: freshDashboardRes.pending_loan.loan_purpose ?? "",
-              other_purpose: freshDashboardRes.pending_loan.loan_purpose_other ?? "",
+              other_purpose:
+                freshDashboardRes.pending_loan.loan_purpose_other ?? "",
               wapan_member:
                 freshDashboardRes.pending_loan.wapan_member ?? false,
               account_name:
@@ -38,6 +39,8 @@ export default function Step4Summary() {
                 freshDashboardRes.pending_loan.disbursement_account ?? "",
               bank_name:
                 freshDashboardRes.pending_loan.bank_account?.bank_name ?? "",
+              bank_code:
+                freshDashboardRes.pending_loan.bank_account?.bank_code ?? "",
               repayment_method:
                 freshDashboardRes.pending_loan.repayment_method ?? "",
               recyclable_drop_off_known:
@@ -59,7 +62,6 @@ export default function Step4Summary() {
     fetchAndSyncLoanData();
   }, [dashboardData.pending_loan, refreshDashboardData, updateLoanFormData]);
 
-
   const onSubmit = async () => {
     setLoading(true);
 
@@ -70,8 +72,9 @@ export default function Step4Summary() {
       account_name: loanFormData.account_name,
       account_number: loanFormData.account_number,
       bank_name: loanFormData.bank_name,
+      bank_code: loanFormData.bank_code,
       recyclable_drop_off_known: loanFormData.recyclable_drop_off_known,
-      
+
       repayment_method: loanFormData.repayment_method,
       repayment_schedule: loanFormData.repayment_schedule,
     };
@@ -94,14 +97,14 @@ export default function Step4Summary() {
         const updatedLoanDetails = await updatePendingLoanDetails(
           payload,
           // pendingLoanID
-          dashboardData.pending_loan._id
+          dashboardData.pending_loan._id,
         );
         if (updatedLoanDetails.status === 200) {
           setFormSuccess(updatedLoanDetails.data?.message);
           // save updatedLoanDetails and navigate to overview page
           localStorage.setItem(
             "latestLoanApplicationData",
-            JSON.stringify(updatedLoanDetails.data?.data)
+            JSON.stringify(updatedLoanDetails.data?.data),
           );
           setTimeout(() => {
             navigate("/take-a-loan/loan-repayment-overview");
@@ -125,7 +128,7 @@ export default function Step4Summary() {
           setFormSuccess(response.data?.message);
           localStorage.setItem(
             "latestLoanApplicationData",
-            JSON.stringify(response.data?.data)
+            JSON.stringify(response.data?.data),
           );
           setTimeout(() => {
             navigate("/take-a-loan/loan-repayment-overview");

--- a/src/context/LoanFormContext.jsx
+++ b/src/context/LoanFormContext.jsx
@@ -14,6 +14,7 @@ const emptyLoanFormData = {
   account_name: "",
   account_number: "",
   bank_name: "",
+  bank_code: "",
   repayment_method: "",
   recyclable_drop_off_known: "",
   repayment_schedule: "",
@@ -64,6 +65,7 @@ export function LoanFormProvider({ children }) {
           account_name: restoredData.bank_account?.account_name ?? "",
           account_number: restoredData.bank_account?.account_number ?? "",
           bank_name: restoredData.bank_account?.bank_name ?? "",
+          bank_code: restoredData.bank_account?.bank_code ?? "",
           repayment_method: restoredData.repayment_method ?? "",
           recyclable_drop_off_known:
             restoredData.recyclable_drop_off_known ?? false,


### PR DESCRIPTION
## Summary
- Stores selected bank code in loan form state
- Includes `bank_code` in loan apply/update payloads
- Restores bank code from pending loan data when available

## Testing
-  `npm run build` ran successfully
- Verified selected bank includes expected `bank_code` in loan application payload